### PR TITLE
Fix the link highlighting and update dependencies

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -76,8 +76,8 @@ module.exports = {
         GAViewID: `174800394`,
         minimumThreshold: 0.03,
         period: {
-          startDate: new Date("2018-1-1"),
-          endDate: new Date("2018-5-5"),
+          startDate: new Date("2018-5-10"),
+          endDate: new Date("2018-5-17"),
         },
       },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,17 +5,17 @@
   "requires": true,
   "dependencies": {
     "@angular/compiler": {
-      "version": "5.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-5.2.10.tgz",
-      "integrity": "sha512-FI9ip+aWGpKQB+VfNbFQ+wyh0K4Th8Q/MrHxW6CN4BYVAfFtfORRohvyyYk0sRxuQO8JFN3W/FFfdXjuL+cZKw==",
+      "version": "5.2.11",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-5.2.11.tgz",
+      "integrity": "sha512-ICvB1ud1mxaXUYLb8vhJqiLhGBVocAZGxoHTglv6hMkbrRYcnlB3FZJFOzBvtj+krkd1jamoYLI43UAmesqQ6Q==",
       "requires": {
         "tslib": "^1.7.1"
       }
     },
     "@angular/compiler-cli": {
-      "version": "5.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-5.2.10.tgz",
-      "integrity": "sha512-RhI26rVALRn3LrU0CAIEj56m60vLyCd8e2Ah79yRP6vlXL8k6SylXytUljTeXIBtiVu2Bi1qKGf2s1X674GzCw==",
+      "version": "5.2.11",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-5.2.11.tgz",
+      "integrity": "sha512-dwrQ0yxoCM/XzKzlm7pTsyg4/6ECjT9emZufGj8t12bLMO8NDn1IJOsqXJA1+onEgQKhlr0Ziwi+96TvDTb1Cg==",
       "requires": {
         "chokidar": "^1.4.2",
         "minimist": "^1.2.0",
@@ -56,37 +56,37 @@
       }
     },
     "@angular/core": {
-      "version": "5.2.10",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-5.2.10.tgz",
-      "integrity": "sha512-glDuTtHTcAVhfU3NVewxz/W+Iweq5IaeW2tnMa+RKLopYk9fRs8eR5iTixTGvegwKR770vfXg/gR7P6Ii5cYGQ==",
+      "version": "5.2.11",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-5.2.11.tgz",
+      "integrity": "sha512-h2vpvXNAdOqKzbVaZcHnHGMT5A8uDnizk6FgGq6SPyw9s3d+/VxZ9LJaPjUk3g2lICA7og1tUel+2YfF971MlQ==",
       "requires": {
         "tslib": "^1.7.1"
       }
     },
     "@babel/code-frame": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz",
-      "integrity": "sha512-7BKRkmYaPZm3Yff5HGZJKCz7RqZ5jUjknsXT6Gz5YKG23J3uq9hAj0epncCB0rlqmnZ8Q+UUpQB2tCR5mT37vw==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.47.tgz",
+      "integrity": "sha512-W7IeG4MoVf4oUvWfHUx9VG9if3E0xSUDf1urrnNYtC2ow1dz2ptvQ6YsJfyVXDuPTFXz66jkHhzMW7a5Eld7TA==",
       "requires": {
-        "@babel/highlight": "7.0.0-beta.46"
+        "@babel/highlight": "7.0.0-beta.47"
       }
     },
     "@babel/core": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.46.tgz",
-      "integrity": "sha512-lCDbBSAhNAt+nL98xbgWmuhgrIxKvbvFHf73zlNCuXCHJkdlo7qzTofYK0ZWb+OVce8fQ17fC7DwTIhAwowzMw==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.47.tgz",
+      "integrity": "sha512-7EIuAX0UVnCgZ0E9tz9rFK0gd+aovwMA9bul+dnkmBQYLrJdas2EHMUSmaK67i1cyZpvgVvXhHtXJxC7wo3rlQ==",
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.46",
-        "@babel/generator": "7.0.0-beta.46",
-        "@babel/helpers": "7.0.0-beta.46",
-        "@babel/template": "7.0.0-beta.46",
-        "@babel/traverse": "7.0.0-beta.46",
-        "@babel/types": "7.0.0-beta.46",
-        "babylon": "7.0.0-beta.46",
+        "@babel/code-frame": "7.0.0-beta.47",
+        "@babel/generator": "7.0.0-beta.47",
+        "@babel/helpers": "7.0.0-beta.47",
+        "@babel/template": "7.0.0-beta.47",
+        "@babel/traverse": "7.0.0-beta.47",
+        "@babel/types": "7.0.0-beta.47",
+        "babylon": "7.0.0-beta.47",
         "convert-source-map": "^1.1.0",
         "debug": "^3.1.0",
         "json5": "^0.5.0",
-        "lodash": "^4.2.0",
+        "lodash": "^4.17.5",
         "micromatch": "^2.3.11",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
@@ -94,215 +94,215 @@
       }
     },
     "@babel/generator": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.46.tgz",
-      "integrity": "sha512-5VfaEVkPG0gpNSTcf70jvV+MjbMoNn4g2iluwM7MhciedkolEtmG7PcdoUj5W1EmMfngz5cF65V7UMZXJO6y8Q==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.47.tgz",
+      "integrity": "sha512-fJP+9X+gqgTTZzTqrKJHwebPwt6S/e/4YuyRyKyWHAIirGgUwjRoZgbFci24wwGYMJW7nlkCSwWG7QvCVsG0eg==",
       "requires": {
-        "@babel/types": "7.0.0-beta.46",
+        "@babel/types": "7.0.0-beta.47",
         "jsesc": "^2.5.1",
-        "lodash": "^4.2.0",
+        "lodash": "^4.17.5",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.46.tgz",
-      "integrity": "sha512-ej5W347ghJF1p2TM3VcEyds1+o1uy1apaQcHrYFJPus2xCgn5KkHPkBGf+6euLfFaQDtB+eWPVKjiZx/hpYXvA==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.47.tgz",
+      "integrity": "sha512-Pjxb/PrxyKWc7jcAXlawvNAQMxxY+tSSNC5wxJstJjpO10mocmGzBOqNYjxdvVhMb3d0BEPQ8mR+D65fFpZ+TA==",
       "requires": {
-        "@babel/types": "7.0.0-beta.46"
+        "@babel/types": "7.0.0-beta.47"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.46.tgz",
-      "integrity": "sha512-ZCQ62KqFC5R3NPe5ug9pVqIHYJNup8UdEbE4IXw+s7zr4D/7AsKSt3pXA+FbML5AnQXeCSOuUWioggGmKuDV5g==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.47.tgz",
+      "integrity": "sha512-nv8d6TcDBb1CJMQzwab/e0rqyqoP9d2AQBjr4GdSiVRpJX4aiLEiLBm2XprdEb/sVIRmmBnVxPXJaHDsS/K2fw==",
       "requires": {
-        "@babel/helper-explode-assignable-expression": "7.0.0-beta.46",
-        "@babel/types": "7.0.0-beta.46"
+        "@babel/helper-explode-assignable-expression": "7.0.0-beta.47",
+        "@babel/types": "7.0.0-beta.47"
       }
     },
     "@babel/helper-builder-react-jsx": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.46.tgz",
-      "integrity": "sha512-4xakEEfimusXNgpSY6rP7robwRcnv1E8OxjkYSfsZCYsomFwN7RXU5S29vGWzxE37Yua4yTFqBwId9lwF84Hzw==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.47.tgz",
+      "integrity": "sha512-oBGX/MyT4kNGuINK2k/KLHD77Ih1oTROtoxnV3uAPS9rLYhmZn3W8qy2L4bbyMwQ89nVSM427b0bTTXUEEReXA==",
       "requires": {
-        "@babel/types": "7.0.0-beta.46",
+        "@babel/types": "7.0.0-beta.47",
         "esutils": "^2.0.0"
       }
     },
     "@babel/helper-call-delegate": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.46.tgz",
-      "integrity": "sha512-7nhBu/MBlpvZLQsmw/C7VxN14wph+yp+1yxzPEd2oTsHg3oA73tHyguQ6wbtkw+9f1AZtP7ZJCLQ+nGLprF4Fw==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.47.tgz",
+      "integrity": "sha512-Rx9TRmCCEP0pWau9gfR6ubcbbX3nVc4ImNY143ftC70jrKdSv5rS20yz2cmCilDzhexwGZQ3PFwOLKe3C/5aEg==",
       "requires": {
-        "@babel/helper-hoist-variables": "7.0.0-beta.46",
-        "@babel/traverse": "7.0.0-beta.46",
-        "@babel/types": "7.0.0-beta.46"
+        "@babel/helper-hoist-variables": "7.0.0-beta.47",
+        "@babel/traverse": "7.0.0-beta.47",
+        "@babel/types": "7.0.0-beta.47"
       }
     },
     "@babel/helper-define-map": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.46.tgz",
-      "integrity": "sha512-rhi59ZVj+bhrgxqLi9VQmQOadcK9rLCArY8zqyjPNjDIsCurCwtQztRWhlz6CwBEhE9FO/KbSa9OFQm7Kobk+w==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.47.tgz",
+      "integrity": "sha512-pLB9RY7GZKcc/frzgfDY/HwdqxWPe60qMAvNUef1V1bDZ8i4AUgxAANgltFzj61t100WGhqaS0xGkALD+9VA+g==",
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.46",
-        "@babel/types": "7.0.0-beta.46",
-        "lodash": "^4.2.0"
+        "@babel/helper-function-name": "7.0.0-beta.47",
+        "@babel/types": "7.0.0-beta.47",
+        "lodash": "^4.17.5"
       }
     },
     "@babel/helper-explode-assignable-expression": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.46.tgz",
-      "integrity": "sha512-SW1OUmx2fC2SqL7+vF1N72FITbPuEWGdr/Gm7I3Vqs8p8T1dfGwB9YFsD+tTpfagKXVMiCCuQ06+G0FB8uxg6Q==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.47.tgz",
+      "integrity": "sha512-1mwk27zmhSuMUcVWxw5ZKiPYfuWXviZNqgA4OvFBloPf9R+dKDhNgP2uUrkHh68ltVVc3Bup1nsbd/2KM5AxEw==",
       "requires": {
-        "@babel/traverse": "7.0.0-beta.46",
-        "@babel/types": "7.0.0-beta.46"
+        "@babel/traverse": "7.0.0-beta.47",
+        "@babel/types": "7.0.0-beta.47"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.46.tgz",
-      "integrity": "sha512-zm4Kc5XB2njGs8PkmjV1zE/g1hBuphbh+VcDyFLaQsxkxSFSUtCbKwFL8AQpL/qPIcGbvX1MBt50a/3ZZH2CQA==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.47.tgz",
+      "integrity": "sha512-0LSvt95XCYaOrDA5K68KkTyldKXizDwBnKACdYzQszp1GdbtzmSeGwFU5Ecw86fU6bkYXtDvkFTOQwk/WQSJPw==",
       "requires": {
-        "@babel/helper-get-function-arity": "7.0.0-beta.46",
-        "@babel/template": "7.0.0-beta.46",
-        "@babel/types": "7.0.0-beta.46"
+        "@babel/helper-get-function-arity": "7.0.0-beta.47",
+        "@babel/template": "7.0.0-beta.47",
+        "@babel/types": "7.0.0-beta.47"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.46.tgz",
-      "integrity": "sha512-dPrTb7QHVx44xJLjUl3LGAc13iS7hdXdO0fiOxdRN1suIS91yGGgeuwiQBlrw5SxbFchYtwenhlKbqHdVfGyVA==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.47.tgz",
+      "integrity": "sha512-63j0i3YUW8CO//uQc3ACffJdIlYcIlysuHjMF0yzQhqKoQ/CUPv0hf3nBwdRGjiWrr3JcL6++NF4XmXdwSU+fA==",
       "requires": {
-        "@babel/types": "7.0.0-beta.46"
+        "@babel/types": "7.0.0-beta.47"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.46.tgz",
-      "integrity": "sha512-9xDHLfaVA445mcHU2OEPwEddiyS0Zxao2WObFR2L/SK5MNOPj2VqVCvivYrO2OpzhnLLCTbOfXRmrwrc9WYN6Q==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.47.tgz",
+      "integrity": "sha512-5BcKFhyzrsInlrfO/tGoe6khUuJzGfROD7oozF/5MWsKo/c3gVJfQ5y83lZ4XoTKJt/x4PQlLU0aHd/SJpYONA==",
       "requires": {
-        "@babel/types": "7.0.0-beta.46"
+        "@babel/types": "7.0.0-beta.47"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.46.tgz",
-      "integrity": "sha512-Xb5iVUHXY8yz4pgGBvtuS1kxZH1oUYcxTcbIW8NFRvgpeH3Zcv4me02bbixsk7nhn8ttE79Lr1g4vrem4k5Z3Q==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.47.tgz",
+      "integrity": "sha512-gpipslnZw2hcVGADUtqQII9KF8FPpRZsVUXwKP/0EnWwtujRFSVL+u2Fh+VXODRAxFmTLo6eGcOr/Vfan0MqYw==",
       "requires": {
-        "@babel/types": "7.0.0-beta.46"
+        "@babel/types": "7.0.0-beta.47"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.46.tgz",
-      "integrity": "sha512-xjgpwrqHiKCZgAcqsNIpZ9kOCC5Ty/VYN1H07v21HbAf/dl0/HeUA0taz3EFv6/7lRgS3qThawTSG0POJQX9vQ==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.47.tgz",
+      "integrity": "sha512-Rk43Ty+a6npu9znK22IqFlseStRGWxEHi2cjmLbbi63VGiseofdUtIJI65F9MTCuMTXAX7VbY/ghef1Jp5qpvw==",
       "requires": {
-        "@babel/types": "7.0.0-beta.46",
-        "lodash": "^4.2.0"
+        "@babel/types": "7.0.0-beta.47",
+        "lodash": "^4.17.5"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.46.tgz",
-      "integrity": "sha512-IckoWSub3PHNvkWcUEWfKBe8pFUdMhsZMFDcaovcLb+gfxL/zZhQYwedKKKwbzVGIk9k44yjeMQ/OJd4yt4FGQ==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.47.tgz",
+      "integrity": "sha512-CziMe30ZunAhe6j05oNOFOg7im1lcv3dYuMxrwBYVe9YdP4NHPU7a1wrDBUhaPmyqTIZDwGnFne7k1KP79SeGQ==",
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.46",
-        "@babel/helper-simple-access": "7.0.0-beta.46",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.46",
-        "@babel/template": "7.0.0-beta.46",
-        "@babel/types": "7.0.0-beta.46",
-        "lodash": "^4.2.0"
+        "@babel/helper-module-imports": "7.0.0-beta.47",
+        "@babel/helper-simple-access": "7.0.0-beta.47",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.47",
+        "@babel/template": "7.0.0-beta.47",
+        "@babel/types": "7.0.0-beta.47",
+        "lodash": "^4.17.5"
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.46.tgz",
-      "integrity": "sha512-PVd7/PGxi82pEKyuDcEpMmlenMLhJCII3lIK4MhXGWrT/6cNMpY6ob5rWOarpXgZjy+JNI5uLPOce28bqq0Wtw==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.47.tgz",
+      "integrity": "sha512-NhnGhjwrhzGas4A/PoBDEtEPCGJHrzhaT6qGmo1hmkA2orG4UNi7KENC38DhJII0n2oUrKUuzTwgCvxKOTiHbw==",
       "requires": {
-        "@babel/types": "7.0.0-beta.46"
+        "@babel/types": "7.0.0-beta.47"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.46.tgz",
-      "integrity": "sha512-eRTFH+/1rqDfzx+Z//CYk4TNwhfPQpM/TCs4CmHu2DwCPrqFnKUZLI1KgStfLf//c8FdOqx/U9EPec7s8CbUIA=="
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+      "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
     },
     "@babel/helper-regex": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.46.tgz",
-      "integrity": "sha512-sPDHBt8Y4i6y9rwtxWMvcprlVHAZOOQK5xpS2Nw2q9QEDHRHwVbEpE6EejoUStSclnfJpPK/7ijFgypwc6rXlA==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.47.tgz",
+      "integrity": "sha512-dafidvVkjJP5AIWkJspV+7RGj1jeNts0qYvlmVzqAGb6BmQzEldJr6ZPzrmlpW/AW1YJGdw7br2yiwvlCRqDvQ==",
       "requires": {
-        "lodash": "^4.2.0"
+        "lodash": "^4.17.5"
       }
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.46.tgz",
-      "integrity": "sha512-YrqQ98z8AMZx8f2PGJ4YV1MkXtj+qbwbFV7MOLTiavGSFY7UrN4uQfhKEJ/4GUf4QZdTr5NEmRt0AJrWno8y8w==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.47.tgz",
+      "integrity": "sha512-Nmj3lUHQscD160asav2bZ3sMIjGwGY9r6Vrriy9TqH7bmaClKUKUs5Twv0htFWfOKNFLEeY/MaqiAXylr1GS2w==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.46",
-        "@babel/helper-wrap-function": "7.0.0-beta.46",
-        "@babel/template": "7.0.0-beta.46",
-        "@babel/traverse": "7.0.0-beta.46",
-        "@babel/types": "7.0.0-beta.46"
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.47",
+        "@babel/helper-wrap-function": "7.0.0-beta.47",
+        "@babel/template": "7.0.0-beta.47",
+        "@babel/traverse": "7.0.0-beta.47",
+        "@babel/types": "7.0.0-beta.47"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.46.tgz",
-      "integrity": "sha512-FSpK3QKzb58oMEccanHzg1djsYHhGARl08i8BQGBoOyHS6Df+4/8bsQiTnc59Dz5sJoZdb67nKKFjgMsMYi6Kg==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.47.tgz",
+      "integrity": "sha512-yf2JAD1+xNTjavqazqknRgPfd6MbGfvfIcAkxWsPURynAwOMSs4zThED8ImT2d5a97rGPysRJcq1jNh2L0WYxg==",
       "requires": {
-        "@babel/helper-member-expression-to-functions": "7.0.0-beta.46",
-        "@babel/helper-optimise-call-expression": "7.0.0-beta.46",
-        "@babel/traverse": "7.0.0-beta.46",
-        "@babel/types": "7.0.0-beta.46"
+        "@babel/helper-member-expression-to-functions": "7.0.0-beta.47",
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.47",
+        "@babel/traverse": "7.0.0-beta.47",
+        "@babel/types": "7.0.0-beta.47"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.46.tgz",
-      "integrity": "sha512-1OEjV/Qnl4u8Dg+jQIYf1TgnfdrYIrdrF7yZwp9mSgsVX2PCyLe7JNTqZ/5v/5RzlF6S+GTe9agkj+EFFTcZUw==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.47.tgz",
+      "integrity": "sha512-sd2t3QDKjd+hHkJKaC2AX39l6oIil1N548oMZAtV5YHlVGoWWkAVGnPMxRg7ICEjIftCU3ZI6UeaogyEhF8t7Q==",
       "requires": {
-        "@babel/template": "7.0.0-beta.46",
-        "@babel/types": "7.0.0-beta.46",
-        "lodash": "^4.2.0"
+        "@babel/template": "7.0.0-beta.47",
+        "@babel/types": "7.0.0-beta.47",
+        "lodash": "^4.17.5"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.46.tgz",
-      "integrity": "sha512-UT7acgV7wsnBPwnqslqcnUFvsPBP4TtVaYM82xPGA7+evAa8q8HXOmFk08qsMK/pX/yy4+51gJJwyw2zofnacA==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.47.tgz",
+      "integrity": "sha512-jx8GmxryT6Qy4+24W6M6TnVL9T8bxqdyg5UKHjxBdw0Y2Sano1n0WphUS2seuOugn04W2ZQLqGc0ut8nGe/taA==",
       "requires": {
-        "@babel/types": "7.0.0-beta.46"
+        "@babel/types": "7.0.0-beta.47"
       }
     },
     "@babel/helper-wrap-function": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.46.tgz",
-      "integrity": "sha512-W87M4bP6veTKK66OjzV/rU47tjsWmKj9J0J5BDmxq5BIJB1M13ouQ2FAURa4jGHwjPFWN3D5njBrsrifSOHzbQ==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.47.tgz",
+      "integrity": "sha512-SAasvh80Mz5q9x15dqH6z8jpM0WTBmxQSNZATSwJwhmWdme6r2gxpufIMr8LwQIJHmXmgNLmvh0zdWSbE/PR4Q==",
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.46",
-        "@babel/template": "7.0.0-beta.46",
-        "@babel/traverse": "7.0.0-beta.46",
-        "@babel/types": "7.0.0-beta.46"
+        "@babel/helper-function-name": "7.0.0-beta.47",
+        "@babel/template": "7.0.0-beta.47",
+        "@babel/traverse": "7.0.0-beta.47",
+        "@babel/types": "7.0.0-beta.47"
       }
     },
     "@babel/helpers": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.46.tgz",
-      "integrity": "sha512-mbpH9pM3pJzo/tBr75U+zva3pqpyivogt1aofgEoD7bWFAYSuqOudRuz+m4XP6VPxxLoxcA4SFPGkuLRt9+7nQ==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.47.tgz",
+      "integrity": "sha512-uWk7gIua2COEWLwZGxfF5Wq1bgXOt1V6xzWxqeFznrA6F1TUPiAhkK5zORiZEa5RAILp6Mswsn3xFjDyCpp3rQ==",
       "requires": {
-        "@babel/template": "7.0.0-beta.46",
-        "@babel/traverse": "7.0.0-beta.46",
-        "@babel/types": "7.0.0-beta.46"
+        "@babel/template": "7.0.0-beta.47",
+        "@babel/traverse": "7.0.0-beta.47",
+        "@babel/types": "7.0.0-beta.47"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.46.tgz",
-      "integrity": "sha512-r4snW6Q8ICL3Y8hGzYJRvyG/+sc+kvkewXNedG9tQjoHmUFMwMSv/o45GWQUQswevGnWghiGkpRPivFfOuMsOA==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.47.tgz",
+      "integrity": "sha512-d505K3Hth1eg0b2swfEF7oFMw3J9M8ceFg0s6dhCSxOOF+07WDvJ0HKT/YbK/Jk9wn8Wyr6HIRAUPKJ9Wfv8Rg==",
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -310,527 +310,527 @@
       }
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.46.tgz",
-      "integrity": "sha512-htHMsLBYkM89CplqHTbbemVvzTXXyXkpihetJZUTPpSayfxEd6oIH5uSM91efcf5Rog+1SC0Oq32q9yF/4W3ig==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.47.tgz",
+      "integrity": "sha512-TQMLYVIqQ0MqVS1Z7jsuv3HlEetLo/7EnDY9mGBZ4c4/WLD/mu+tFuLiK2/2QH5wgi5viRfJGs/+L5TaDzxWng==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/helper-remap-async-to-generator": "7.0.0-beta.46",
-        "@babel/plugin-syntax-async-generators": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47",
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.47",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-proposal-class-properties": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-beta.46.tgz",
-      "integrity": "sha512-kWp3bKibdSeSEvEQWcEcs345KPQYT39uM2edFS78NH3Gu6O9mBcnXh5E2BJ1sbE+jJ6jYPOZz4BK/LR7BiF0jA==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-beta.47.tgz",
+      "integrity": "sha512-6yuCiF+ZZHPLgAa+0a6/teNeAMsWqY6AVtZA4NhCWnwP4OH0JrRaY7rwvFCJSqNGurf8rF65W9IucM/l0+HOCg==",
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.46",
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/helper-replace-supers": "7.0.0-beta.46",
-        "@babel/plugin-syntax-class-properties": "7.0.0-beta.46"
+        "@babel/helper-function-name": "7.0.0-beta.47",
+        "@babel/helper-plugin-utils": "7.0.0-beta.47",
+        "@babel/helper-replace-supers": "7.0.0-beta.47",
+        "@babel/plugin-syntax-class-properties": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.46.tgz",
-      "integrity": "sha512-viGuWOgFT/Tbnn3sYi3g9iJcC3ql7bSjxDs+d+GFgyf3eV2qNIKO/6I+PJAD35fGqDGGBrQhlA6HvW0FzQVtoA==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.47.tgz",
+      "integrity": "sha512-ujUjQUyTxUWHfixRD7Y5Nm8VCgHSf6YgbM37LEnojKp5lPahZO42qJfDty+Kh0tEanpI5H8BLPkJbFSzx6TNEw==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.46.tgz",
-      "integrity": "sha512-ZorB1i84PiVCFmrxglRaDDepmIknWgt8k5jA+IHmPd0/8UN5iMz2RLdIgIhyl92091DgsNxnVI50KLvGNK3++Q==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.47.tgz",
+      "integrity": "sha512-XMZavW6uior8KD4BeMavxF3PGrwVpIFlZk/GJQGkd3lOeOHil8nhHDuTWvsbsJptKFWMPkhGR18boNdxgmxyFQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.46.tgz",
-      "integrity": "sha512-H1F53Sc7mvVxAGzs1nH7IVs4Gh6tYx9azyaMzv92RUvLYQsRm6pKaX1dQtOHJMLMgY61i65y29fQ40mvwIhfFA==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.47.tgz",
+      "integrity": "sha512-TCQqSmPrgVB0Txr6WzCpxJyLuVTb9KoT0+oECKELtF717bvHOI4woR7o8D8DFkXzVQeb7Kqfu5w05gsvPq591g==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/helper-regex": "7.0.0-beta.46",
-        "regexpu-core": "^4.1.3"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47",
+        "@babel/helper-regex": "7.0.0-beta.47",
+        "regexpu-core": "^4.1.4"
       }
     },
     "@babel/plugin-syntax-async-generators": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.46.tgz",
-      "integrity": "sha512-igLQzZYcSrY/W3eACq6Nrf9u9mfw7m5G6+JeTZlyI7w0z+upGvWvrpTaAP1Gni6MckQkx5q+pspgpV+/5ioPXg==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.47.tgz",
+      "integrity": "sha512-LCNGYTLpQAsvTmVmT/I2pz7dIh3Bu+9BLxqL7b3QfplsMQxNsoBBMend33Arb4EtPt5dX7KeeVof8tL0trDRRA==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-syntax-class-properties": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0-beta.46.tgz",
-      "integrity": "sha512-NwtgTQ+I8B2eo5h1mZF64nloLaGQuPM4M/c/swvyvqHoWLissHhm94rOE2Ghte8WMgQ/Nw3bqJd59kpbckqmdQ==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0-beta.47.tgz",
+      "integrity": "sha512-vLoAuLSjHSenX3TQmri6ttQWZp3rEtGcRp4LgYEBQ012fN5h+KmcssvkCAqm6V6ozS5KzUWpBlZ6t7YhZG6oBw==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-syntax-dynamic-import": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.46.tgz",
-      "integrity": "sha512-D4ek6tZa80NgaTSprPOVxj8vxjChh6UCWgCT/ZvCwAa6CBe3iqUCuOwZQLjU41aDdeuR7C02wxl3rcb25wCRLA==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.47.tgz",
+      "integrity": "sha512-J2y7RAH2NwQ+ahJahj2eS1PqS2NWNWTDaEibqrE55VTJU7nPL8AhthRwIQfQkCH+8UIeL/T3Jh1iHIRkvJ6dXA==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-syntax-flow": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.0.0-beta.46.tgz",
-      "integrity": "sha512-HFChD9R2w+8+Jt5539SVaKKSYuMvbCgYG7LmuISycaJW16aS6fNS6V8jr8U/HKJk3bhIG5SkATBYedy5zGR+sg==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.0.0-beta.47.tgz",
+      "integrity": "sha512-+3ZLKNV8tSDnTWL4QRNx5uZB/hUzY71WcgCwoXWy+8ma7EjZ3e3vbR69VR8dJwG1DqGsug6ZzM+afR0G4gKgPA==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-syntax-jsx": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.46.tgz",
-      "integrity": "sha512-aYN4vmO4nMux1W36F6/YP2ugNQ0cilrs1eU4jClLrlIouxqd9hqBloWtlGmGlyDxIRV5kzr+UWwridLDb+cN5g==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.47.tgz",
+      "integrity": "sha512-5scuJzIYZY8M+A1ra8mcKANIwB5TtsRD6Aw94xZxfvnjhhVMFR5RYE9HshVlBrZVY+r3cJDNIQLJMC/fGJHImA==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.46.tgz",
-      "integrity": "sha512-MMv6WG69jmcSLXdUeHvoev5RkuP/QuJZwCB4jXp2gtss//avs4Sns+t0VpGKTf9umhvRq44HFO6PVjVG85F+/Q==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.47.tgz",
+      "integrity": "sha512-UOGQCmzvNlZMQOuys7xPiTa2EjTT3xHuhUghcdJnYikqGV43obpIIaP+VDCWPvIT8g0QDIvmRWx5UefvkWXN+w==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-syntax-optional-catch-binding": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.46.tgz",
-      "integrity": "sha512-BRutzJrTLEPUidyRP1n4O2ySAww0wuJw2gIoT4iJ8Pm6qx4fqm/DM0+++TB8nR3/Tp456pHRm0bVOqpkMJdJbg==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.47.tgz",
+      "integrity": "sha512-Dmq+REMR95Syg+VjV3bh63DD/tDxdraNQ4ErAOXFobfSCDbfov9YGkqSJ4K61LHTQwinQ0+dIUlgdFL2kbedIw==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.46.tgz",
-      "integrity": "sha512-GgeFCCMHXWRkPDXWKin76qiZh+DAYdQShmk8SmzDj6IAgPHyNqkxHN/8gsmNe5/7IWFFOKUuM9TNU7fgY7z7Gg==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.47.tgz",
+      "integrity": "sha512-xiU+7RJAsqx+iZqWSQQWBu9ZDTruWimkg4puDSdRVfEwgZQdOtiU2LuO0+xGFyitJPHkKuje0WvK1tFu1dmxCw==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.46.tgz",
-      "integrity": "sha512-obykYLqAd3tujTjHYE+dln5+nDhm+R5FmUcxXFr/Mx6LK1NgrTQ9TdPPOcMCD08r8SDljFpMopuz9upN/xJlbw==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.47.tgz",
+      "integrity": "sha512-/TXK3v6ipvmhMO81Y2Vjc7RYROkS2PcmRc+kvmU3CWA7r5I73KWg10UEW/fpWqCuoTCHHHXu1ZcZ5u+nduJeFw==",
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.46",
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/helper-remap-async-to-generator": "7.0.0-beta.46"
+        "@babel/helper-module-imports": "7.0.0-beta.47",
+        "@babel/helper-plugin-utils": "7.0.0-beta.47",
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.46.tgz",
-      "integrity": "sha512-0paq0AtTp3TXbXdzWwsL8ddacmo/g/14IgIZgs5BzUTrfROKQThYVccEBPqRnprTgvM0JXyDVfNSgLB4akCTjg==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.47.tgz",
+      "integrity": "sha512-8KPxKyE6kb9VRbHwQ8XKsg/IPlxHaOMRyg2WfyV5C4dCmXbRdHDJy4hZKB3o4rGxjggmC/Bx8Fh51/P7UNtTcA==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.46.tgz",
-      "integrity": "sha512-7OwS0ObI6nLacEKP1HCdnoIQnHBqOV6IgtKGiPO+Nj03OnZ1Yo2aeK9sfOtwL43aNztnKqFVt2L5PfZg4VGidA==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.47.tgz",
+      "integrity": "sha512-V/u3Zdy40KjVQeyYUaQnCGiHQbRNJoc6IEtNDERltuW9vYPHS1n6YGc+EHKi8JVYT4kE6UHOjD+BrbCCV4kjRw==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "lodash": "^4.2.0"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47",
+        "lodash": "^4.17.5"
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.46.tgz",
-      "integrity": "sha512-EDp/qQAURfrX6hNM+VrLSSA+cGiwDeZL0ZTTt6a7PNSFABCw4qwKJHx3Q7me1oV7q3U/GJwPS4Aym2QTDmNGvg==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.47.tgz",
+      "integrity": "sha512-hzW/jL6TPBMHJXeXwzuxMN0PFAfjVD0UzATHrFSejY5A7SvhWWrv1cZ3K0/SzCXJ9LpMdxCNiREvVjeD/Tyx2g==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.46",
-        "@babel/helper-define-map": "7.0.0-beta.46",
-        "@babel/helper-function-name": "7.0.0-beta.46",
-        "@babel/helper-optimise-call-expression": "7.0.0-beta.46",
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/helper-replace-supers": "7.0.0-beta.46",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.46",
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.47",
+        "@babel/helper-define-map": "7.0.0-beta.47",
+        "@babel/helper-function-name": "7.0.0-beta.47",
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.47",
+        "@babel/helper-plugin-utils": "7.0.0-beta.47",
+        "@babel/helper-replace-supers": "7.0.0-beta.47",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.47",
         "globals": "^11.1.0"
       }
     },
     "@babel/plugin-transform-computed-properties": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.46.tgz",
-      "integrity": "sha512-0ne9TL53fXH+cBI591R1JSpPhu0d2Wd9dbD8jLCJFV4tlMfqQ+Rcm65RhWWqjEBZfGv2+FuOnwB4HJRHakdW+Q==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.47.tgz",
+      "integrity": "sha512-V78qyzmjj4aq/tjpkMFbV5gPtrx7xdclW1Rn6vV9hIwMSMbtstYEXF4msy614MofvYj6gYbPbNfyhXFIUvz/xw==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.46.tgz",
-      "integrity": "sha512-l9x0+T29Njwp6smLbTIU2HG2s4ROd9DAIQcfciEfpjAqscXEst0M4X9+UvjQsuaOgPFmQTdAn9xOwNFXnRP7Tg==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.47.tgz",
+      "integrity": "sha512-3AaXC9H7qPybJbSs/QMhhj9EZF9MYrb/HRytwki1tckaYifqCJquENIZxDAYmwsWIGIHiq34WqwPRMIsz/b5uQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.46.tgz",
-      "integrity": "sha512-5bO0XvTP+2LFDQ9qT/WaXfyieLtqz1yGsfOuq86VXmwX9tDnBnNS6pCHEGFQ866c1HmlNBWtaXttTTnvWkFBkw==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.47.tgz",
+      "integrity": "sha512-ofB5GwipMoaOH3Qyr5g5FpXWePhIAaD4zMDOoAHDYBPuLWxzAME8YQCa0S3HJf3eTu/HTN/c/G1gDwDB8Z/gKQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/helper-regex": "7.0.0-beta.46",
+        "@babel/helper-plugin-utils": "7.0.0-beta.47",
+        "@babel/helper-regex": "7.0.0-beta.47",
         "regexpu-core": "^4.1.3"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.46.tgz",
-      "integrity": "sha512-mP2+3QQ+ArIMX98zVYSC9XBzV7A/Pxbz+2hPcEAGVeakFYm5AeTkcVHRQzzA21v4ecl0L5LE1XWX9yeK643CWw==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.47.tgz",
+      "integrity": "sha512-r3xNVYTLVasjqTowIr6s+27oc5n7A5TKbB0/4u9FHjF7ONTWaggO8UFbbj07DOJ4Ll2RkigrZA8/D+w2nJ+XlA==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.46.tgz",
-      "integrity": "sha512-acomgoNW/fwWSmBlhH22C9Eyl1Y/vADBSqzyIRWJGpm4frLhd49QQgKXbRGRHUDxyifXuZDF9+3pRhEmi7/HXA==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.47.tgz",
+      "integrity": "sha512-vyGG3kLIXpMuaPL485aqowdWFrxCxXtbzMXy9p1QTK5Q/+9UHpK9XoAVJZGknnsm091m0Ss7spo8uHaxbzYVog==",
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.46",
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.47",
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-flow-strip-types": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.0.0-beta.46.tgz",
-      "integrity": "sha512-ZyMayIXoDPsYYa8FVypQpcxeHX65l6lQ/nA4DRTSJUVvoQDytfNlH3Y3yQhGwyrr2APsCpq4MGmUAp+Id8KWeA==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.0.0-beta.47.tgz",
+      "integrity": "sha512-X/8Gd4CxdBx7LOtW2wPSzr83bYyndqYbnJoUEosPJXOG2aRmgVo4hn+wk97vtDH+hMP7HsTApVBffrZNXS3erA==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/plugin-syntax-flow": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47",
+        "@babel/plugin-syntax-flow": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.46.tgz",
-      "integrity": "sha512-a1gpwuO26szyz5K2FrRrI5nUDgvkaJfZ7GeDtFAH8XyrK/pNdtpW/7DFCf1PdQc6SbEMM/1QXsH7Y2YRkWoTeA==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.47.tgz",
+      "integrity": "sha512-tfH5OMzV9fWLYJTzWDhoRJKr8kvBZWH26jiCgM0ayNq75ES/X947MqMNAgBjJdTAVEV2kOyks2ItgNAJT4rOUw==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.46.tgz",
-      "integrity": "sha512-XyxSW1jm7WKOoPYHUJA0mbOkDFdlHzGR4DzlWAEwXrzEI5ep0ZP1AttAbVkxsF63XG8p2t9VtKlgbyBq4Tyr7A==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.47.tgz",
+      "integrity": "sha512-/5I/f8NCouugsRT6ORB1UjCP3N+Rgv/OB6SzmaeIUEpYYPM6D7WQ+4BaRYXQn4eqtOJmTgxDXYa8FgYtoeqP9A==",
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.46",
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-function-name": "7.0.0-beta.47",
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-literals": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.46.tgz",
-      "integrity": "sha512-Uuo7pRsBkrLrDg6XpOAMfwhKw56SB5qVBniUVM04uf8wf92S2Z5tSPNNfn1iTgphuckAO9vg86l2XJ0Y/QD4YQ==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.47.tgz",
+      "integrity": "sha512-PxBw+52qWypwR76YfS2FlW4wZfp61SjIyt3OSPZeWnf0zVQWNVrlRRunJ7lBYudDYvyMwStAE/VynZ0fHtPgng==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.46.tgz",
-      "integrity": "sha512-GNp7F3EqJlQIMY9sfoDS03P7EHa/+Bdy6PUugTIo1TjZQUnCy3JbeL2YGI4tU8XOHJGHiBKRjFMpeOsjOSmMtw==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.47.tgz",
+      "integrity": "sha512-zW84YqQ5Kt8+t5pYrnFhjWQP2w2wq6Nxz9pozxpnvXP+lhqyJPqNdWM1lcVApORpWL1BF7BlgP08yk+5MVRfGA==",
       "requires": {
-        "@babel/helper-module-transforms": "7.0.0-beta.46",
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-module-transforms": "7.0.0-beta.47",
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.46.tgz",
-      "integrity": "sha512-3wLCWVkEhhQiVqqml4y9G6GJT6WA/mkxQ6TRy+4I46z00WWbEDENJcRTS14oNKzeRIo4yJylbVB1wUCW7HuJ9A==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.47.tgz",
+      "integrity": "sha512-MYoLyexybBJ9ODWWMsMFzxAQey68RzhQNPjfNAYPhPPB3X160EZ5qOjWxRS2rYNvuYAxs6guy5OdrDpESqFSrQ==",
       "requires": {
-        "@babel/helper-module-transforms": "7.0.0-beta.46",
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/helper-simple-access": "7.0.0-beta.46"
+        "@babel/helper-module-transforms": "7.0.0-beta.47",
+        "@babel/helper-plugin-utils": "7.0.0-beta.47",
+        "@babel/helper-simple-access": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.46.tgz",
-      "integrity": "sha512-dCIuCGaE4UyM6cYC/a2veO0vKT/iSjBZ6ux4v/LePXA/N6v9648nwE6CRmCK1/LtRw+eU0sCo+c0TPeALCszYA==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.47.tgz",
+      "integrity": "sha512-bMQy3/jEZRpoUg7RdOouphBO8+7Sfjl7XrO84PtgBx4ck+ZPc4xOlBQyr2rkmsJNmmGLi42nnMI1cZZJT3LVnQ==",
       "requires": {
-        "@babel/helper-hoist-variables": "7.0.0-beta.46",
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-hoist-variables": "7.0.0-beta.47",
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-modules-umd": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.46.tgz",
-      "integrity": "sha512-t54bMSIY5xtb8uK8aM61xZmpjQ7FJ0M/8EiCFDdx7rHff5O9eJUNEGqGaly8ZTbdp80RqbzMkyiD1V+TXYQW/Q==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.47.tgz",
+      "integrity": "sha512-rG7KioAFCLxZ33wNBqUoxPhtXOmVEvnZNIy9wv0fSbNIQr8lO1avZ7SeBL3OZduNvLocqrESt9Xhh1nzb/zOvA==",
       "requires": {
-        "@babel/helper-module-transforms": "7.0.0-beta.46",
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-module-transforms": "7.0.0-beta.47",
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-new-target": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.46.tgz",
-      "integrity": "sha512-VSuIdVFUhlqADj/ymm7NG4BVjGD0sBWWN5sONTLAYzKScGZA58Ys8jSkl1dxeqWnMOEjzo8lTRWxRVvz8HIaMg==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.47.tgz",
+      "integrity": "sha512-2IRZtdoPXJn7KSwrmp0xtLTZ0PnhlQxhcTZ0XZ5wfFXmsZ9vi6AK4whIZ2IXI/c2qrYK9FEYLwR5QRfL5Qe6eQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-object-super": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.46.tgz",
-      "integrity": "sha512-T+TV4rRuTubvjqEwBF5xib3vnfJgjQ62qJqHprTaJDBtF0ofpbv/A6x86EEr51iPymHc84eM+F1zyFEtJvKYwQ==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.47.tgz",
+      "integrity": "sha512-JN6ox2rH1xe6hlsd6/7d2kPjZSA97wH4oOdNOSaNqaFGEFuaP/Je4+ojHMgyHKU2nx9QHNBCTxHEj+ko+Ij6HQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/helper-replace-supers": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47",
+        "@babel/helper-replace-supers": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.46.tgz",
-      "integrity": "sha512-RnkdYrayTlQ0VFoyIjvY/cCp/1lJJkYE2lFcRNg6+Skd3g41PnocsHhQ5NUQjMNogL+RnNan3S/2S/i7S4zm+Q==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.47.tgz",
+      "integrity": "sha512-UzQG8draO+30Y8eNEREuGBfmEHLL7WFxOjmTBbaTrbdOrm/znCUThqcuNz8cyn2nrZbln7M/loQ3stjf9Pt9fQ==",
       "requires": {
-        "@babel/helper-call-delegate": "7.0.0-beta.46",
-        "@babel/helper-get-function-arity": "7.0.0-beta.46",
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-call-delegate": "7.0.0-beta.47",
+        "@babel/helper-get-function-arity": "7.0.0-beta.47",
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-react-display-name": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0-beta.46.tgz",
-      "integrity": "sha512-/a7wwzNrYqReyuOM8rBB9iAOLaubvGHM9w3eUeput/DnEq/V+dJuBgktpF6mw/MQjwjna1B/3BbWsn1PaBw8bw==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0-beta.47.tgz",
+      "integrity": "sha512-Rw1KWihSkGHbqHiQuiFu/beMakDtobW3eLSABw1w3BvRIc/UhBXxwyIxa/q/R9hWFBholAjmx9cKey8FnZPykw==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-react-jsx": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.46.tgz",
-      "integrity": "sha512-b8VtHVQub3h7lXG1ShaCKgGJdra7fRlUK6hx1eCcIWAPYnJMz4soLMSPiXmyjDA5L0CbYmyTkceU1GjbeJmaaw==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.47.tgz",
+      "integrity": "sha512-HGian2BbCsyAqs6LntVVRpjXG9TkzhHfTynjUoMxOFL29doKEy/0s96SMvmbBSR/wMRKMd1OPvCiEYYxqZtr3g==",
       "requires": {
-        "@babel/helper-builder-react-jsx": "7.0.0-beta.46",
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/plugin-syntax-jsx": "7.0.0-beta.46"
+        "@babel/helper-builder-react-jsx": "7.0.0-beta.47",
+        "@babel/helper-plugin-utils": "7.0.0-beta.47",
+        "@babel/plugin-syntax-jsx": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-react-jsx-self": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0-beta.46.tgz",
-      "integrity": "sha512-keXGiKQNzqHXpplpz/Eu+F+OC/k6M3kbEBOqoDbbYeJVmWARVADWwRnCCsW6yevSyON4CTU5mouVadTIY9YSpA==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0-beta.47.tgz",
+      "integrity": "sha512-hlk+iHdlGtUWo1Y//2snSODh4swBaAcnSLC2qHTbWDE5myEO6ZFGV0nVS3eLOictgKFjrzzPZm6P0X/0w5tVBQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/plugin-syntax-jsx": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47",
+        "@babel/plugin-syntax-jsx": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-react-jsx-source": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0-beta.46.tgz",
-      "integrity": "sha512-vSSghGn+ER6d5gBtNnTZAxPxBSs1ngyyVlHse/geHSv7YnzmrCOUrtVl+t4M2/EO3CW2m8nkMfpnMW5FCmg+Zw==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0-beta.47.tgz",
+      "integrity": "sha512-oZ6D9z+qql+tz7PjGp1CaxepxqDQQTusyjeKsWr7NdEa0v2j3sWLkfK4Aa7kU9BT0+j+r/LN4u33UBkBNVoVvw==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/plugin-syntax-jsx": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47",
+        "@babel/plugin-syntax-jsx": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.46.tgz",
-      "integrity": "sha512-P6d8ckSjKlbr/1SL1NBO6ieFxSebTiRWd2R8/styUIizJWQlEB0ITQ7l8vv3jXGjJ0mh7lxBTegXejRkTGKKgw==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.47.tgz",
+      "integrity": "sha512-JEPIiJyqYRfjOYUTZguLkb2HTwudReqLyOljpOXnJ/1ymwsiof4D6ul611DGlMxJMZJGQ6TBi59iY9GoJ6j4Iw==",
       "requires": {
         "regenerator-transform": "^0.12.3"
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-beta.46.tgz",
-      "integrity": "sha512-mdgrBPXF+7cl+Y8dBynUxK90U17fQdH4zBsNxV6GYyI35WiUUZYFiXG2wKZN+1LClhavD9cOnOLpCxaNQy7g2A==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-beta.47.tgz",
+      "integrity": "sha512-RhnhjYsOxmKDGa1ePM5RQWFBYe1PnEZAhXTNEeIwtw1jluEoLL+PCTZDbt/aAcAkZvqwIWccjkNM/FwKTd5Sxw==",
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.46",
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-module-imports": "7.0.0-beta.47",
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.46.tgz",
-      "integrity": "sha512-1QkKFWPsjrvMppycLwjPBXF+usSnGvbTxGe0Q+eIzcZyhabwGCsCgkmDIKMisPSAi6F7bM5H1S8VbE85IW3oRg==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.47.tgz",
+      "integrity": "sha512-+o7/yb0Nrk4Gg/tnBgfBf+G1uGZbtkSluUnj8RyD37ajpDlWmysDjFEHSfktKcuD8YHeGz2M9AYNGcClk1fr/g==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.46.tgz",
-      "integrity": "sha512-R0GvFdJnFrgTlmZfFtCXk81uvq5S3FuY38FnRsxDt6Yx/sE8jCmmrRe7XHZOnXXGP3ZWY9icILUmzWHOf91jbA==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.47.tgz",
+      "integrity": "sha512-LFAozFdfT4bE2AQw2BnjzLufTX4GBsTUHUGRhT8XNoDYuGnV+7k9Yj6JU3/7csJc9u6W91PArYgoO+D56CMw6Q==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.46.tgz",
-      "integrity": "sha512-goMgOLODjG1cgFHlKACh/NT/wrnmuRi2CpXsjOan10eZce0fk9kahYz/04cqhppmwtV/vQWwH2ikAHODSD8r5w==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.47.tgz",
+      "integrity": "sha512-+Rc6NihGoXcwAqAxbiumvzOYxRR0aUg1ZExfyHnI5QnQf0sf4xAfgT/YpGvEgLd5Ci0rka+IWSj54PhzZkhuTg==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/helper-regex": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47",
+        "@babel/helper-regex": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-template-literals": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.46.tgz",
-      "integrity": "sha512-2iGMsHWVAQq9X6p3VNjktJCH6ZXHQHi3NTPLKh5d4bEW8+M3H7LXLNqk1yUm/Uwt0tzh1FUfb/EU2sEPbrBrVA==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.47.tgz",
+      "integrity": "sha512-ORfrfN/gQoRuI+xf+kOa2i/yvXfedFRgH+KtgoIrpUQom7OhexxzD280x80LMCIkdaVGzYhvlC3kdJkFMWAfUg==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.46",
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.47",
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.46.tgz",
-      "integrity": "sha512-l+CfLR2c5KzZ/uZlkflNe7nK2hiEahc/FeiUCTd5Krj4aCKDdLLSdb4Lowf5hdZbqIPQc9TdL9SZt80YhUlmFw==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.47.tgz",
+      "integrity": "sha512-PhPy5NUY5MT++fEr7/sxN1/ERSM2siHSbGgdkbqgDlyvf1NlU1HeqyfomHJEFE1Y4PX0hj+XmtjSAali/6XqYA==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.46.tgz",
-      "integrity": "sha512-XWQ7uJ0HL/xdMesKzt1uq5CmZPBqDiEno+FBeYuOJu1IWjpr3yXfEzH/nW17KESXGRv68mLTr+fIeSwcC+qVFg==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.47.tgz",
+      "integrity": "sha512-44nWn421tMVZ/A4+1uppzoAO7nrlwWzefMr9JUi5G+tXl0DLEtWy+F7L6zCVw19C4OAOA6WlolVro5CEs6g6AQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/helper-regex": "7.0.0-beta.46",
+        "@babel/helper-plugin-utils": "7.0.0-beta.47",
+        "@babel/helper-regex": "7.0.0-beta.47",
         "regexpu-core": "^4.1.3"
       }
     },
     "@babel/polyfill": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.0.0-beta.46.tgz",
-      "integrity": "sha512-eFFWNiI3Os7bBkIA10ZGBUMywK+1/OTVg+qsrlaXRBTpAN0n1g1pXCkNN4rcGpgLPNyfZHQEj+aVAyWPGerSIQ==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.0.0-beta.47.tgz",
+      "integrity": "sha512-jDKBjX1K/fUNrPGo3wDKEWIXDHZEgpsKTRo3B4Ox5cq5Hxcp219ez/oGofDjNMUJAUI+gfsQfRarMkC5f3uiYw==",
       "requires": {
         "core-js": "^2.5.3",
         "regenerator-runtime": "^0.11.1"
       }
     },
     "@babel/preset-env": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-beta.46.tgz",
-      "integrity": "sha512-zC+QsTmteh2c1CtjeskvUKsqvRpgwBZxOxTk6p+F3gL6uJszP4OWzffgPrsV2wo9vccppTaCzYMFeiJscnne6g==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-beta.47.tgz",
+      "integrity": "sha512-ZFUgKdQDqw2H5TCMaWq6iDDO9+16RZPdDfOuoPID8Agm8I2MBlrqTI1MKWwqgEHICdZIOXkVszAMuuDTBwdzHA==",
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.46",
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.46",
-        "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.46",
-        "@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.46",
-        "@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.46",
-        "@babel/plugin-syntax-async-generators": "7.0.0-beta.46",
-        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.46",
-        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.46",
-        "@babel/plugin-transform-arrow-functions": "7.0.0-beta.46",
-        "@babel/plugin-transform-async-to-generator": "7.0.0-beta.46",
-        "@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.46",
-        "@babel/plugin-transform-block-scoping": "7.0.0-beta.46",
-        "@babel/plugin-transform-classes": "7.0.0-beta.46",
-        "@babel/plugin-transform-computed-properties": "7.0.0-beta.46",
-        "@babel/plugin-transform-destructuring": "7.0.0-beta.46",
-        "@babel/plugin-transform-dotall-regex": "7.0.0-beta.46",
-        "@babel/plugin-transform-duplicate-keys": "7.0.0-beta.46",
-        "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.46",
-        "@babel/plugin-transform-for-of": "7.0.0-beta.46",
-        "@babel/plugin-transform-function-name": "7.0.0-beta.46",
-        "@babel/plugin-transform-literals": "7.0.0-beta.46",
-        "@babel/plugin-transform-modules-amd": "7.0.0-beta.46",
-        "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.46",
-        "@babel/plugin-transform-modules-systemjs": "7.0.0-beta.46",
-        "@babel/plugin-transform-modules-umd": "7.0.0-beta.46",
-        "@babel/plugin-transform-new-target": "7.0.0-beta.46",
-        "@babel/plugin-transform-object-super": "7.0.0-beta.46",
-        "@babel/plugin-transform-parameters": "7.0.0-beta.46",
-        "@babel/plugin-transform-regenerator": "7.0.0-beta.46",
-        "@babel/plugin-transform-shorthand-properties": "7.0.0-beta.46",
-        "@babel/plugin-transform-spread": "7.0.0-beta.46",
-        "@babel/plugin-transform-sticky-regex": "7.0.0-beta.46",
-        "@babel/plugin-transform-template-literals": "7.0.0-beta.46",
-        "@babel/plugin-transform-typeof-symbol": "7.0.0-beta.46",
-        "@babel/plugin-transform-unicode-regex": "7.0.0-beta.46",
+        "@babel/helper-module-imports": "7.0.0-beta.47",
+        "@babel/helper-plugin-utils": "7.0.0-beta.47",
+        "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.47",
+        "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.47",
+        "@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.47",
+        "@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.47",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.47",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.47",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.47",
+        "@babel/plugin-transform-arrow-functions": "7.0.0-beta.47",
+        "@babel/plugin-transform-async-to-generator": "7.0.0-beta.47",
+        "@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.47",
+        "@babel/plugin-transform-block-scoping": "7.0.0-beta.47",
+        "@babel/plugin-transform-classes": "7.0.0-beta.47",
+        "@babel/plugin-transform-computed-properties": "7.0.0-beta.47",
+        "@babel/plugin-transform-destructuring": "7.0.0-beta.47",
+        "@babel/plugin-transform-dotall-regex": "7.0.0-beta.47",
+        "@babel/plugin-transform-duplicate-keys": "7.0.0-beta.47",
+        "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.47",
+        "@babel/plugin-transform-for-of": "7.0.0-beta.47",
+        "@babel/plugin-transform-function-name": "7.0.0-beta.47",
+        "@babel/plugin-transform-literals": "7.0.0-beta.47",
+        "@babel/plugin-transform-modules-amd": "7.0.0-beta.47",
+        "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.47",
+        "@babel/plugin-transform-modules-systemjs": "7.0.0-beta.47",
+        "@babel/plugin-transform-modules-umd": "7.0.0-beta.47",
+        "@babel/plugin-transform-new-target": "7.0.0-beta.47",
+        "@babel/plugin-transform-object-super": "7.0.0-beta.47",
+        "@babel/plugin-transform-parameters": "7.0.0-beta.47",
+        "@babel/plugin-transform-regenerator": "7.0.0-beta.47",
+        "@babel/plugin-transform-shorthand-properties": "7.0.0-beta.47",
+        "@babel/plugin-transform-spread": "7.0.0-beta.47",
+        "@babel/plugin-transform-sticky-regex": "7.0.0-beta.47",
+        "@babel/plugin-transform-template-literals": "7.0.0-beta.47",
+        "@babel/plugin-transform-typeof-symbol": "7.0.0-beta.47",
+        "@babel/plugin-transform-unicode-regex": "7.0.0-beta.47",
         "browserslist": "^3.0.0",
         "invariant": "^2.2.2",
         "semver": "^5.3.0"
       }
     },
     "@babel/preset-flow": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.0.0-beta.46.tgz",
-      "integrity": "sha512-jMr6EbFKPnh1vLLMFxqpac+DSEbfQQLdjllePy4b58fD1Z/F7uG5L52S5WdqGBuHr/dZysHAhexI72BKFWSEXg==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.0.0-beta.47.tgz",
+      "integrity": "sha512-wh9kGw341dcocCUu0O4gquH2uKxOREf7LJ4aQBuCxGLX5rduOQ2jrr2nXJ7dAnpdR0lciyzpnBCXDaRJUhRhPg==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/plugin-transform-flow-strip-types": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47",
+        "@babel/plugin-transform-flow-strip-types": "7.0.0-beta.47"
       }
     },
     "@babel/preset-react": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0-beta.46.tgz",
-      "integrity": "sha512-+Xl9AH/rhI7FTX0OxNXM4oGljpeCs1nwPm2IjD9+mXO/+dWdGpa+yTcjYYpIWAK4KQrSQ+27T6DtJ6fZPTqYQA==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0-beta.47.tgz",
+      "integrity": "sha512-fK4B101W19JsOc8E/wqmQ8R7gE1+DQJqIWvpaQIXPHgW+27ezq2JP5j5IBCk+9OTz007l7se00kMvvtUcKQZwg==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.46",
-        "@babel/plugin-syntax-jsx": "7.0.0-beta.46",
-        "@babel/plugin-transform-react-display-name": "7.0.0-beta.46",
-        "@babel/plugin-transform-react-jsx": "7.0.0-beta.46",
-        "@babel/plugin-transform-react-jsx-self": "7.0.0-beta.46",
-        "@babel/plugin-transform-react-jsx-source": "7.0.0-beta.46"
+        "@babel/helper-plugin-utils": "7.0.0-beta.47",
+        "@babel/plugin-syntax-jsx": "7.0.0-beta.47",
+        "@babel/plugin-transform-react-display-name": "7.0.0-beta.47",
+        "@babel/plugin-transform-react-jsx": "7.0.0-beta.47",
+        "@babel/plugin-transform-react-jsx-self": "7.0.0-beta.47",
+        "@babel/plugin-transform-react-jsx-source": "7.0.0-beta.47"
       }
     },
     "@babel/runtime": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.46.tgz",
-      "integrity": "sha512-/3a3USMKk54BEHhDgY8rtxtaQOs4bp4aQwo6SDtdwmrXmgSgEusWuXNX5oIs/nwzmTD9o8wz2EyAjA+uHDMmJA==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.47.tgz",
+      "integrity": "sha512-3IaakAC5B4bHJ0aCUKVw0pt+GruavdgWDFbf7TfKh7ZJ8yQuUp7af7MNwf3e+jH8776cjqYmMO1JNDDAE9WfrA==",
       "requires": {
         "core-js": "^2.5.3",
         "regenerator-runtime": "^0.11.1"
       }
     },
     "@babel/template": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.46.tgz",
-      "integrity": "sha512-3/qi4m0l6G/vZbEwtqfzJk73mYtuE7nvAO1zT3/ZrTAHy4sHf2vaF9Eh1w+Tau263Yrkh0bjVQPb9zw6G+GeMQ==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.47.tgz",
+      "integrity": "sha512-mAzrOCLwOb4jAobHi0kTwIkoamP1Do28c6zxvrDXjYSJFZHz6KGuzMaT0AV7ZCq7M3si7QypVVMVX2bE6IsuOg==",
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.46",
-        "@babel/types": "7.0.0-beta.46",
-        "babylon": "7.0.0-beta.46",
-        "lodash": "^4.2.0"
+        "@babel/code-frame": "7.0.0-beta.47",
+        "@babel/types": "7.0.0-beta.47",
+        "babylon": "7.0.0-beta.47",
+        "lodash": "^4.17.5"
       }
     },
     "@babel/traverse": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.46.tgz",
-      "integrity": "sha512-IU7MTGbcjpfhf5tyCu3sDB7sWYainZQcT+CqOBdVZXZfq5MMr130R7aiZBI2g5dJYUaW1PS81DVNpd0/Sq/Gzg==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.47.tgz",
+      "integrity": "sha512-kYGGs//OnUnei+9TTldxlgf7llprj7VUeDKtG50+g+0k1g0yZyrkEgbyFheYFdnudR8IDEHOEXVsUuY82r5Aiw==",
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.46",
-        "@babel/generator": "7.0.0-beta.46",
-        "@babel/helper-function-name": "7.0.0-beta.46",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.46",
-        "@babel/types": "7.0.0-beta.46",
-        "babylon": "7.0.0-beta.46",
+        "@babel/code-frame": "7.0.0-beta.47",
+        "@babel/generator": "7.0.0-beta.47",
+        "@babel/helper-function-name": "7.0.0-beta.47",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.47",
+        "@babel/types": "7.0.0-beta.47",
+        "babylon": "7.0.0-beta.47",
         "debug": "^3.1.0",
         "globals": "^11.1.0",
         "invariant": "^2.2.0",
-        "lodash": "^4.2.0"
+        "lodash": "^4.17.5"
       }
     },
     "@babel/types": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.46.tgz",
-      "integrity": "sha512-uA5aruF2KKsJxToWdDpftsrPOIQtoGrGno2hiaeO9JRvfT9xZdK11nPoC+/RF9emNzmNbWn4HCRdCY+McT5Nbw==",
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+      "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.2.0",
+        "lodash": "^4.17.5",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -842,6 +842,11 @@
         "call-me-maybe": "^1.0.1",
         "glob-to-regexp": "^0.3.0"
       }
+    },
+    "@nodelib/fs.stat": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.0.2.tgz",
+      "integrity": "sha512-vCpf75JDcdomXvUd7Rn6DfYAVqPAFI66FVjxiWGwh85OLdvfo3paBoPJaam5keIYRyUolnS7SleS/ZPCidCvzw=="
     },
     "@types/configstore": {
       "version": "2.1.1",
@@ -889,9 +894,9 @@
       "integrity": "sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY="
     },
     "@types/node": {
-      "version": "7.0.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.63.tgz",
-      "integrity": "sha512-YPVhjU3cADo7M7M1KWeEki9MUMZd3yz5FLq0BXkPrY2jpr0B9VRd4iQ2vBSiLrjvLkIPPluzxQFYJ5JkGubtIw=="
+      "version": "7.0.64",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.64.tgz",
+      "integrity": "sha512-i8KiWTXKD8O76LjlTt+lK/8CUY/FDLbw5djHNrEK1SjOM6MAcZhvhskCX8vsujdxVD+UeX7SvusEzchLY4UBYQ=="
     },
     "@types/opn": {
       "version": "5.1.0",
@@ -902,17 +907,17 @@
       }
     },
     "@types/react": {
-      "version": "16.3.13",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.13.tgz",
-      "integrity": "sha512-YMFH/E9ryjUm2AoOy8KdTuG1SufaMuYmO/5xACROl0pm9dRmE2RN3d2zjv/eHALF6LGRZPVb7G9kqP0n5dWttQ==",
+      "version": "16.3.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.14.tgz",
+      "integrity": "sha512-wNUGm49fPl7eE2fnYdF0v5vSOrUMdKMQD/4NwtQRnb6mnPwtkhabmuFz37eq90+hhyfz0pWd38jkZHOcaZ6LGw==",
       "requires": {
         "csstype": "^2.2.0"
       }
     },
     "@types/react-router": {
-      "version": "4.0.24",
-      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-4.0.24.tgz",
-      "integrity": "sha512-uYY+o2+d2+ZzcIkkzwkdybKnGTbH5ooBuHlkPnZMl2/YlmsVgwAwCxS8HYDle3VdnYxILZe9dUSa1mchg6RPWw==",
+      "version": "4.0.25",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-4.0.25.tgz",
+      "integrity": "sha512-IsFvDwQy2X08g+tRMvugH1l7e0kkR+o5qEUkFfYLmjw2jGCPogY2bBuRAgZCZ5CSUswdNTkKtPUmNo+f6afyfg==",
       "requires": {
         "@types/history": "*",
         "@types/react": "*"
@@ -934,139 +939,145 @@
       "integrity": "sha1-DTyzECL4Qn6ljACK8yuA2hJspOM="
     },
     "@webassemblyjs/ast": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.3.1.tgz",
-      "integrity": "sha512-WJKy500MK6cM5LNcOjKlLHnYtTU5PcmL06iXErYriA90GLn7W/EzIyknZRx0Bj3W6FjYKTPkHADdE3GM0ZJk1Q==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.4.3.tgz",
+      "integrity": "sha512-S6npYhPcTHDYe9nlsKa9CyWByFi8Vj8HovcAgtmMAQZUOczOZbQ8CnwMYKYC5HEZzxEE+oY0jfQk4cVlI3J59Q==",
       "requires": {
-        "@webassemblyjs/helper-wasm-bytecode": "1.3.1",
-        "@webassemblyjs/wast-parser": "1.3.1",
-        "webassemblyjs": "1.3.1"
+        "@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+        "@webassemblyjs/wast-parser": "1.4.3",
+        "debug": "^3.1.0",
+        "webassemblyjs": "1.4.3"
       }
     },
     "@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.3.1.tgz",
-      "integrity": "sha512-8kCRyt0bQSnZD67UQfDTONO0jD7HCxmNUUJfT9OnVok0RWYs/AnpS83kfHtQjHucRMyx2d+YlsJWkdhXdLobqA=="
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.4.3.tgz",
+      "integrity": "sha512-3zTkSFswwZOPNHnzkP9ONq4bjJSeKVMcuahGXubrlLmZP8fmTIJ58dW7h/zOVWiFSuG2em3/HH3BlCN7wyu9Rw=="
     },
     "@webassemblyjs/helper-buffer": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.3.1.tgz",
-      "integrity": "sha512-xIcxcfkBrrivLauyXJ57i/ArPy+kFgZjMDrxm4pSUBG2VtwwYKjOZAyjf4qsM4JbP5vRuRzMD2gp+a9WMyC3PA=="
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.4.3.tgz",
+      "integrity": "sha512-e8+KZHh+RV8MUvoSRtuT1sFXskFnWG9vbDy47Oa166xX+l0dD5sERJ21g5/tcH8Yo95e9IN3u7Jc3NbhnUcSkw==",
+      "requires": {
+        "debug": "^3.1.0"
+      }
     },
     "@webassemblyjs/helper-code-frame": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.3.1.tgz",
-      "integrity": "sha512-X305tLl7qeTixYz0/Y0Xu+bcNizJLfHUZ1iTiVtorDkh5mLrIZ8hLkkM2oYNSq/oaoW6gpHDrHRfYZItExTeeQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.4.3.tgz",
+      "integrity": "sha512-9FgHEtNsZQYaKrGCtsjswBil48Qp1agrzRcPzCbQloCoaTbOXLJ9IRmqT+uEZbenpULLRNFugz3I4uw18hJM8w==",
       "requires": {
-        "@webassemblyjs/wast-printer": "1.3.1"
+        "@webassemblyjs/wast-printer": "1.4.3"
       }
     },
     "@webassemblyjs/helper-fsm": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.3.1.tgz",
-      "integrity": "sha512-Be1G8ZDTP1T+vXaVMraXY8+SoJnOVNarRkByrM83PHjW+vqUwubwYPpA4U2NBTz4WG19vYpfsUccCZwOPiyK+Q=="
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.4.3.tgz",
+      "integrity": "sha512-JINY76U+702IRf7ePukOt037RwmtH59JHvcdWbTTyHi18ixmQ+uOuNhcdCcQHTquDAH35/QgFlp3Y9KqtyJsCQ=="
     },
     "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.3.1.tgz",
-      "integrity": "sha512-rOIjy/Cmd+hspim9B/c7dUqhW8AyKsRceVcQtWljIvFSitx9rsL5m73NGaGFUVAEaMDvvEzYczehjwbrHPz4KA=="
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.4.3.tgz",
+      "integrity": "sha512-I7bS+HaO0K07Io89qhJv+z1QipTpuramGwUSDkwEaficbSvCcL92CUZEtgykfNtk5wb0CoLQwWlmXTwGbNZUeQ=="
     },
     "@webassemblyjs/helper-wasm-section": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.3.1.tgz",
-      "integrity": "sha512-mDBlDsrsl1Y7LGEdmlTzdDwr/SCe2l9ZsQZ1GYXird71jlU/0djs5ZXfxyufd1G3wO+yuxW997m50Patk4s1fA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.4.3.tgz",
+      "integrity": "sha512-p0yeeO/h2r30PyjnJX9xXSR6EDcvJd/jC6xa/Pxg4lpfcNi7JUswOpqDToZQ55HMMVhXDih/yqkaywHWGLxqyQ==",
       "requires": {
-        "@webassemblyjs/ast": "1.3.1",
-        "@webassemblyjs/helper-buffer": "1.3.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.3.1",
-        "@webassemblyjs/wasm-gen": "1.3.1"
+        "@webassemblyjs/ast": "1.4.3",
+        "@webassemblyjs/helper-buffer": "1.4.3",
+        "@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+        "@webassemblyjs/wasm-gen": "1.4.3",
+        "debug": "^3.1.0"
       }
     },
     "@webassemblyjs/leb128": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.3.1.tgz",
-      "integrity": "sha512-CgkWUXRINTGs/+Swp8COvwOk5Ci4spv1MKDdGfRecyFiLGs7wYm/p4fgRQWzBEFaotEP/ftPa9O6BFykrwghzw==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.4.3.tgz",
+      "integrity": "sha512-4u0LJLSPzuRDWHwdqsrThYn+WqMFVqbI2ltNrHvZZkzFPO8XOZ0HFQ5eVc4jY/TNHgXcnwrHjONhPGYuuf//KQ==",
       "requires": {
         "leb": "^0.3.0"
       }
     },
     "@webassemblyjs/validation": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/validation/-/validation-1.3.1.tgz",
-      "integrity": "sha512-afp32tgDVwW53lQc58PtIBifyZf3qGzRpl9r+8SNHzPOe6lBamjK1RWEA83YHwvu7qk6uBV7IAeUC7BgdxPtsA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/validation/-/validation-1.4.3.tgz",
+      "integrity": "sha512-R+rRMKfhd9mq0rj2mhU9A9NKI2l/Rw65vIYzz4lui7eTKPcCu1l7iZNi4b9Gen8D42Sqh/KGiaQNk/x5Tn/iBQ==",
       "requires": {
-        "@webassemblyjs/ast": "1.3.1"
+        "@webassemblyjs/ast": "1.4.3"
       }
     },
     "@webassemblyjs/wasm-edit": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.3.1.tgz",
-      "integrity": "sha512-0T75tHKR0dIDiO3oqBZmo+2McJy5FkgSL2AIP3rJvqrDFaJ19jCrC5KLqGbqo3ZicdY9x9Xdc9zaY2A1TCkAiw==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.4.3.tgz",
+      "integrity": "sha512-qzuwUn771PV6/LilqkXcS0ozJYAeY/OKbXIWU3a8gexuqb6De2p4ya/baBeH5JQ2WJdfhWhSvSbu86Vienttpw==",
       "requires": {
-        "@webassemblyjs/ast": "1.3.1",
-        "@webassemblyjs/helper-buffer": "1.3.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.3.1",
-        "@webassemblyjs/helper-wasm-section": "1.3.1",
-        "@webassemblyjs/wasm-gen": "1.3.1",
-        "@webassemblyjs/wasm-opt": "1.3.1",
-        "@webassemblyjs/wasm-parser": "1.3.1",
-        "@webassemblyjs/wast-printer": "1.3.1",
+        "@webassemblyjs/ast": "1.4.3",
+        "@webassemblyjs/helper-buffer": "1.4.3",
+        "@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+        "@webassemblyjs/helper-wasm-section": "1.4.3",
+        "@webassemblyjs/wasm-gen": "1.4.3",
+        "@webassemblyjs/wasm-opt": "1.4.3",
+        "@webassemblyjs/wasm-parser": "1.4.3",
+        "@webassemblyjs/wast-printer": "1.4.3",
         "debug": "^3.1.0"
       }
     },
     "@webassemblyjs/wasm-gen": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.3.1.tgz",
-      "integrity": "sha512-iYgQ3UJpsKiJnXerHulT//JpJAHuLavqMPEtUiRnSh0r/WvZh8pNtYBaN2v64+d9yTtu9aMlJmlKi6uz1j5FFg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.4.3.tgz",
+      "integrity": "sha512-eR394T8dHZfpLJ7U/Z5pFSvxl1L63JdREebpv9gYc55zLhzzdJPAuxjBYT4XqevUdW67qU2s0nNA3kBuNJHbaQ==",
       "requires": {
-        "@webassemblyjs/ast": "1.3.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.3.1",
-        "@webassemblyjs/leb128": "1.3.1"
+        "@webassemblyjs/ast": "1.4.3",
+        "@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+        "@webassemblyjs/leb128": "1.4.3"
       }
     },
     "@webassemblyjs/wasm-opt": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.3.1.tgz",
-      "integrity": "sha512-Eqi1he5VuGxMYKGhrBU+UxUhIwTDlnuvJmwrad3k4dD2UQpqu3HedRndGdJTQ68xj2GqDCdE6QiLzjytSN4KVQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.4.3.tgz",
+      "integrity": "sha512-7Gp+nschuKiDuAL1xmp4Xz0rgEbxioFXw4nCFYEmy+ytynhBnTeGc9W9cB1XRu1w8pqRU2lbj2VBBA4cL5Z2Kw==",
       "requires": {
-        "@webassemblyjs/ast": "1.3.1",
-        "@webassemblyjs/helper-buffer": "1.3.1",
-        "@webassemblyjs/wasm-gen": "1.3.1",
-        "@webassemblyjs/wasm-parser": "1.3.1"
+        "@webassemblyjs/ast": "1.4.3",
+        "@webassemblyjs/helper-buffer": "1.4.3",
+        "@webassemblyjs/wasm-gen": "1.4.3",
+        "@webassemblyjs/wasm-parser": "1.4.3",
+        "debug": "^3.1.0"
       }
     },
     "@webassemblyjs/wasm-parser": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.3.1.tgz",
-      "integrity": "sha512-euRnqP/bky9DGbXf5Nqvtmc5soOM7xkvwI2H+LSP88NAFkcGMPEnrAP4UbsFAH+ESnS4kAW6wL5UyzjWBiiTbA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.4.3.tgz",
+      "integrity": "sha512-KXBjtlwA3BVukR/yWHC9GF+SCzBcgj0a7lm92kTOaa4cbjaTaa47bCjXw6cX4SGQpkncB9PU2hHGYVyyI7wFRg==",
       "requires": {
-        "@webassemblyjs/ast": "1.3.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.3.1",
-        "@webassemblyjs/leb128": "1.3.1",
-        "@webassemblyjs/wasm-parser": "1.3.1",
-        "webassemblyjs": "1.3.1"
+        "@webassemblyjs/ast": "1.4.3",
+        "@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+        "@webassemblyjs/leb128": "1.4.3",
+        "@webassemblyjs/wasm-parser": "1.4.3",
+        "webassemblyjs": "1.4.3"
       }
     },
     "@webassemblyjs/wast-parser": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.3.1.tgz",
-      "integrity": "sha512-lM7Kwsp1mqqL3jq1kXKeoT8Z/cXvPQ2kWBNg19nZXbL1eLgr+4qRi83WvQU45+5+uIovigtBw/WU0nLLev7LGA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.4.3.tgz",
+      "integrity": "sha512-QhCsQzqV0CpsEkRYyTzQDilCNUZ+5j92f+g35bHHNqS22FppNTywNFfHPq8ZWZfYCgbectc+PoghD+xfzVFh1Q==",
       "requires": {
-        "@webassemblyjs/ast": "1.3.1",
-        "@webassemblyjs/floating-point-hex-parser": "1.3.1",
-        "@webassemblyjs/helper-code-frame": "1.3.1",
-        "@webassemblyjs/helper-fsm": "1.3.1",
+        "@webassemblyjs/ast": "1.4.3",
+        "@webassemblyjs/floating-point-hex-parser": "1.4.3",
+        "@webassemblyjs/helper-code-frame": "1.4.3",
+        "@webassemblyjs/helper-fsm": "1.4.3",
         "long": "^3.2.0",
-        "webassemblyjs": "1.3.1"
+        "webassemblyjs": "1.4.3"
       }
     },
     "@webassemblyjs/wast-printer": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.3.1.tgz",
-      "integrity": "sha512-V2SMByzsrTT2wGQOjm/3ctCiy8mdYOSLDk+EkOpNHVZWB9ISJc+gZWzniTgihih03UWqqNa1S/0XpyVz7ZEYSQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.4.3.tgz",
+      "integrity": "sha512-EgXk4anf8jKmuZJsqD8qy5bz2frEQhBvZruv+bqwNoLWUItjNSFygk8ywL3JTEz9KtxTlAmqTXNrdD1d9gNDtg==",
       "requires": {
-        "@webassemblyjs/ast": "1.3.1",
-        "@webassemblyjs/wast-parser": "1.3.1",
+        "@webassemblyjs/ast": "1.4.3",
+        "@webassemblyjs/wast-parser": "1.4.3",
         "long": "^3.2.0"
       }
     },
@@ -2024,9 +2035,9 @@
       }
     },
     "babel-plugin-remove-graphql-queries": {
-      "version": "2.0.1-4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.0.1-4.tgz",
-      "integrity": "sha1-KXtx9RyV3LduRiBWcsmQu7XNwSY="
+      "version": "2.0.1-7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.0.1-7.tgz",
+      "integrity": "sha1-vApiqldZ1AMCym9vvIvByQebZFU="
     },
     "babel-plugin-syntax-class-properties": {
       "version": "6.13.0",
@@ -2410,9 +2421,9 @@
       }
     },
     "babylon": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.46.tgz",
-      "integrity": "sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg=="
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
+      "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
     },
     "backo2": {
       "version": "1.0.2",
@@ -2503,11 +2514,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
       "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
-    },
-    "base64url": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
-      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
     },
     "basic-auth": {
       "version": "2.0.0",
@@ -2763,12 +2769,12 @@
       }
     },
     "browserslist": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.6.tgz",
-      "integrity": "sha512-XCsMSg9V4S1VRdcp265dJ+8kBRjfuFXcavbisY7G6T9QI0H1Z24PP53vvs0WDYWqm38Mco1ILDtafcS8ZR4xiw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.7.tgz",
+      "integrity": "sha512-oYVLxFVqpX9uMhOIQBLtZL+CX4uY8ZpWcjNTaxyWl5rO8yA9SSNikFnAfvk8J3P/7z3BZwNmEqFKaJoYltj3MQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30000830",
-        "electron-to-chromium": "^1.3.42"
+        "caniuse-lite": "^1.0.30000835",
+        "electron-to-chromium": "^1.3.45"
       }
     },
     "bser": {
@@ -2960,14 +2966,14 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000836",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000836.tgz",
-      "integrity": "sha1-eItsj28CmRdDsYzbvVT5bQW0uVo="
+      "version": "1.0.30000842",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000842.tgz",
+      "integrity": "sha1-ioLDd7iz1vJZRHjoQx/0/TA+Fgw="
     },
     "caniuse-lite": {
-      "version": "1.0.30000836",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000836.tgz",
-      "integrity": "sha512-DlVR8sVTKDgd7t95U0shX3g7MeJ/DOjKOhUcaiXqnVmnO5sG4Tn2rLVOkVfPUJgnQNxnGe8/4GK0dGSI+AagQw=="
+      "version": "1.0.30000842",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000842.tgz",
+      "integrity": "sha512-juspQHLwQRgptEM03HN66SpM/ggZUB+m49NAgJIaIS11aXVNeRB57sEY1X6tEzeK2THGvYWKZZu1wIbh+W7YTA=="
     },
     "capture-stack-trace": {
       "version": "1.0.0",
@@ -3455,6 +3461,11 @@
         "xdg-basedir": "^3.0.0"
       }
     },
+    "confusing-browser-globals": {
+      "version": "2.0.0-next.66cc7a90",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-2.0.0-next.66cc7a90.tgz",
+      "integrity": "sha512-pVhpqs/CvjFgJm6pIamnHI7xxutxywZr4WaG7/g3+1uTrJldBS+jKe/4NvGv0etgAAY6z2+iaogt4pkXM+6wag=="
+    },
     "connect-history-api-fallback": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
@@ -3703,24 +3714,6 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
-    "css-color-function": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/css-color-function/-/css-color-function-1.3.3.tgz",
-      "integrity": "sha1-jtJMLAIFBzM5+voAS8jBQfzLKC4=",
-      "requires": {
-        "balanced-match": "0.1.0",
-        "color": "^0.11.0",
-        "debug": "^3.1.0",
-        "rgb": "~0.1.0"
-      },
-      "dependencies": {
-        "balanced-match": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
-          "integrity": "sha1-tQS9BYabOSWd0MXvw12EMXbczEo="
-        }
-      }
-    },
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -3847,11 +3840,6 @@
           }
         }
       }
-    },
-    "css-unit-converter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
-      "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY="
     },
     "css-what": {
       "version": "2.1.0",
@@ -3984,9 +3972,9 @@
       }
     },
     "csstype": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.4.2.tgz",
-      "integrity": "sha512-1TnkyZwDy0oUl//6685j2bTMNe61SzntWntijNdmmEzvpYbGmVMZkj204gv4glcQp6z/ypg+YRziT91XVFmOyg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.2.tgz",
+      "integrity": "sha512-epoHrKPywwUhFTXadQNA5PPx4GChtkM03SkBeFZTaFtJcn6QfXpBkX2IAc4J9Oe18nha5NrTOo2OMOge+qH1mw=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -4197,9 +4185,9 @@
       "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
     },
     "detect-port": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.2.2.tgz",
-      "integrity": "sha512-06H99JMCwgbYbA+codm97aBhFLAjABftetp+v+Z88Pvvlkawp2N+1bP/9J24+mihrvk9yBvUYTyIj3NixG1CsA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.2.3.tgz",
+      "integrity": "sha512-IDbrX6PxqnYy8jV4wSHBaJlErYKTJvW8OQb9F7xivl1iQLqiUYHGa+nZ61Do6+N5uuOn/pReXKNqI9rUn04vug==",
       "requires": {
         "address": "^1.0.1",
         "debug": "^2.6.0"
@@ -4413,11 +4401,10 @@
       }
     },
     "ecdsa-sig-formatter": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
-      "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
-        "base64url": "^2.0.0",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -4427,9 +4414,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.45",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.45.tgz",
-      "integrity": "sha1-RYrBscXHYM6IEaFtK/vZfsMLr7g="
+      "version": "1.3.47",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.47.tgz",
+      "integrity": "sha1-dk6IfKkQTQGgrI6r7n38DizhQQQ="
     },
     "elliptic": {
       "version": "6.4.0",
@@ -4728,9 +4715,12 @@
       }
     },
     "eslint-config-react-app": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-2.1.0.tgz",
-      "integrity": "sha512-8QZrKWuHVC57Fmu+SsKAVxnI9LycZl7NFQ4H9L+oeISuCXhYdXqsOOIVSjQFW6JF5MXZLFE+21Syhd7mF1IRZQ=="
+      "version": "3.0.0-next.66cc7a90",
+      "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-3.0.0-next.66cc7a90.tgz",
+      "integrity": "sha512-6J+fEOLy7uE+fxpGERi8Yts9vNEgul6AXbHhdvGRj+4Xpus7jR7Q4fu1oXmnuRwVPBxJ/MQkcpdFa2m8iBG20Q==",
+      "requires": {
+        "confusing-browser-globals": "2.0.0-next.66cc7a90"
+      }
     },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
@@ -4825,9 +4815,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.11.0.tgz",
-      "integrity": "sha1-Fa7qN6Z0mdhI6OmBgG1GJ7VQOBY=",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.12.0.tgz",
+      "integrity": "sha1-2tMXgSktZmSyUxf9BJ0uKy8CIF0=",
       "requires": {
         "contains-path": "^0.1.0",
         "debug": "^2.6.8",
@@ -4861,9 +4851,9 @@
       }
     },
     "eslint-plugin-jsx-a11y": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.1.1.tgz",
-      "integrity": "sha512-5I9SpoP7gT4wBFOtXT8/tXNPYohHBVfyVfO17vkbC7r9kEIxYJF12D3pKqhk8+xnk12rfxKClS3WCFpVckFTPQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.3.tgz",
+      "integrity": "sha1-VFg9GuRCSDFi4EDhPMMYZUZRAOU=",
       "requires": {
         "aria-query": "^0.7.0",
         "array-includes": "^3.0.3",
@@ -4871,28 +4861,18 @@
         "axobject-query": "^0.1.0",
         "damerau-levenshtein": "^1.0.0",
         "emoji-regex": "^6.1.0",
-        "jsx-ast-utils": "^1.4.0"
+        "jsx-ast-utils": "^2.0.0"
       }
     },
     "eslint-plugin-react": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
-      "integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.8.2.tgz",
+      "integrity": "sha512-H3ne8ob4Bn6NXSN9N9twsn7t8dyHT5bF/ibQepxIHi6JiPIdC2gXlfYvZYucbdrWio4FxBq7Z4mSauQP+qmMkQ==",
       "requires": {
         "doctrine": "^2.0.2",
         "has": "^1.0.1",
         "jsx-ast-utils": "^2.0.1",
         "prop-types": "^15.6.0"
-      },
-      "dependencies": {
-        "jsx-ast-utils": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-          "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
-          "requires": {
-            "array-includes": "^3.0.3"
-          }
-        }
       }
     },
     "eslint-scope": {
@@ -5155,11 +5135,12 @@
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-glob": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.1.tgz",
-      "integrity": "sha512-wSyW1TBK3ia5V+te0rGPXudeMHoUQW6O5Y9oATiaGhpENmEifPDlOdhpsnlj5HoG6ttIvGiY1DdCmI9X2xGMhg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
+      "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
       "requires": {
         "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "@nodelib/fs.stat": "^1.0.1",
         "glob-parent": "^3.1.0",
         "is-glob": "^4.0.0",
         "merge2": "^1.2.1",
@@ -5545,13 +5526,13 @@
       "integrity": "sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g=="
     },
     "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "requires": {
         "is-number": "^2.1.0",
         "isobject": "^2.0.0",
-        "randomatic": "^1.1.3",
+        "randomatic": "^3.0.0",
         "repeat-element": "^1.1.2",
         "repeat-string": "^1.5.2"
       }
@@ -5836,13 +5817,13 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
-      "integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "optional": true,
       "requires": {
         "nan": "^2.9.2",
-        "node-pre-gyp": "^0.9.0"
+        "node-pre-gyp": "^0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -5911,7 +5892,7 @@
           }
         },
         "deep-extend": {
-          "version": "0.4.2",
+          "version": "0.5.1",
           "bundled": true,
           "optional": true
         },
@@ -6067,7 +6048,7 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.9.1",
+          "version": "0.10.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6163,11 +6144,11 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.6",
+          "version": "1.2.7",
           "bundled": true,
           "optional": true,
           "requires": {
-            "deep-extend": "~0.4.0",
+            "deep-extend": "^0.5.1",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
@@ -6308,30 +6289,30 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gatsby": {
-      "version": "2.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.0.0-alpha.30.tgz",
-      "integrity": "sha1-W/icVzQ2SGafN+T6pEpomyWuFr8=",
+      "version": "2.0.0-alpha.38",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.0.0-alpha.38.tgz",
+      "integrity": "sha1-cGfl5K0JebbB+0uVWb3A7wfkZk4=",
       "requires": {
-        "@babel/code-frame": "^7.0.0-beta.42",
-        "@babel/core": "^7.0.0-beta.42",
-        "@babel/plugin-proposal-class-properties": "^7.0.0-beta.42",
-        "@babel/plugin-syntax-dynamic-import": "^7.0.0-beta.42",
-        "@babel/plugin-transform-runtime": "^7.0.0-beta.42",
-        "@babel/polyfill": "^7.0.0-beta.42",
-        "@babel/preset-env": "^7.0.0-beta.42",
-        "@babel/preset-flow": "^7.0.0-beta.42",
-        "@babel/preset-react": "^7.0.0-beta.42",
-        "@babel/runtime": "^7.0.0-beta.42",
-        "@babel/traverse": "^7.0.0-beta.42",
+        "@babel/code-frame": "7.0.0-beta.47",
+        "@babel/core": "7.0.0-beta.47",
+        "@babel/plugin-proposal-class-properties": "7.0.0-beta.47",
+        "@babel/plugin-syntax-dynamic-import": "7.0.0-beta.47",
+        "@babel/plugin-transform-runtime": "7.0.0-beta.47",
+        "@babel/polyfill": "7.0.0-beta.47",
+        "@babel/preset-env": "7.0.0-beta.47",
+        "@babel/preset-flow": "7.0.0-beta.47",
+        "@babel/preset-react": "7.0.0-beta.47",
+        "@babel/runtime": "7.0.0-beta.47",
+        "@babel/traverse": "7.0.0-beta.47",
         "async": "^2.1.2",
         "autoprefixer": "^7.1.2",
-        "babel-core": "^7.0.0-0",
+        "babel-core": "7.0.0-bridge.0",
         "babel-eslint": "^8.2.2",
         "babel-loader": "8.0.0-beta.0",
         "babel-plugin-add-module-exports": "^0.2.1",
         "babel-plugin-dynamic-import-node": "^1.2.0",
-        "babel-plugin-remove-graphql-queries": "^2.0.1-4",
-        "babylon": "^7.0.0-beta.38",
+        "babel-plugin-remove-graphql-queries": "^2.0.1-7",
+        "babylon": "7.0.0-beta.47",
         "better-queue": "^3.8.6",
         "bluebird": "^3.5.0",
         "chalk": "^2.3.2",
@@ -6348,13 +6329,13 @@
         "domready": "^1.0.8",
         "dotenv": "^4.0.0",
         "eslint": "^4.19.1",
-        "eslint-config-react-app": "^2.1.0",
+        "eslint-config-react-app": "3.0.0-next.66cc7a90",
         "eslint-loader": "^2.0.0",
         "eslint-plugin-flowtype": "^2.46.1",
         "eslint-plugin-graphql": "^2.0.0",
         "eslint-plugin-import": "^2.9.0",
-        "eslint-plugin-jsx-a11y": "^5.1.1",
-        "eslint-plugin-react": "^7.7.0",
+        "eslint-plugin-jsx-a11y": "^6.0.3",
+        "eslint-plugin-react": "^7.8.2",
         "express": "^4.16.3",
         "express-graphql": "^0.6.12",
         "fast-levenshtein": "~2.0.4",
@@ -6363,13 +6344,13 @@
         "friendly-errors-webpack-plugin": "^1.6.1",
         "front-matter": "^2.1.0",
         "fs-extra": "^5.0.0",
-        "gatsby-cli": "^1.1.41-4",
-        "gatsby-link": "^1.6.38-6",
-        "gatsby-react-router-scroll": "^1.0.12-4",
+        "gatsby-cli": "^1.1.41-7",
+        "gatsby-link": "^1.6.38-9",
+        "gatsby-react-router-scroll": "^1.0.12-7",
         "glob": "^7.1.1",
         "graphql": "^0.13.2",
         "graphql-relay": "^0.5.5",
-        "graphql-skip-limit": "^2.0.0-alpha.2",
+        "graphql-skip-limit": "^2.0.0-alpha.5",
         "history": "^4.6.2",
         "invariant": "^2.2.4",
         "is-relative": "^1.0.0",
@@ -6395,12 +6376,8 @@
         "opn": "^5.3.0",
         "parse-filepath": "^1.0.1",
         "path-exists": "^3.0.0",
-        "postcss-browser-reporter": "^0.5.0",
-        "postcss-cssnext": "^3.0.2",
         "postcss-flexbugs-fixes": "^3.0.0",
-        "postcss-import": "^11.0.0",
         "postcss-loader": "^2.1.3",
-        "postcss-reporter": "^5.0.0",
         "raw-loader": "^0.5.1",
         "react-dev-utils": "^4.2.1",
         "react-error-overlay": "^3.0.0",
@@ -6436,9 +6413,9 @@
       },
       "dependencies": {
         "gatsby-cli": {
-          "version": "1.1.51",
-          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-1.1.51.tgz",
-          "integrity": "sha1-0IHZiTIu8c7PFFo3n6EPyHtnBTU=",
+          "version": "1.1.52",
+          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-1.1.52.tgz",
+          "integrity": "sha1-G7CWcbd0pJIC6lu5CqSb/uuqL8M=",
           "requires": {
             "babel-code-frame": "^6.26.0",
             "babel-runtime": "^6.26.0",
@@ -6486,46 +6463,54 @@
       }
     },
     "gatsby-plugin-google-analytics": {
-      "version": "1.0.20-5",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-1.0.20-5.tgz",
-      "integrity": "sha1-SVTZsMFU/k28ctACzPfKuvUWzjc=",
+      "version": "1.0.20-8",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-1.0.20-8.tgz",
+      "integrity": "sha1-p28xVLR9pK2K3kfxEqYmoJBBwBs=",
       "requires": {
-        "@babel/runtime": "^7.0.0-beta.42"
+        "@babel/runtime": "7.0.0-beta.47"
+      }
+    },
+    "gatsby-plugin-guess-js": {
+      "version": "1.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-guess-js/-/gatsby-plugin-guess-js-1.0.0-alpha.2.tgz",
+      "integrity": "sha512-TEYu/aG9C9H2vDqC9J+MqnCiLEdEisNbtQEGvNscHATyUtpmOqRW1NKI8KvhPuM73NC1Sqt0AMSNGvXgzjdphg==",
+      "requires": {
+        "@babel/runtime": "^7.0.0-beta.38"
       }
     },
     "gatsby-plugin-manifest": {
-      "version": "2.0.1-9",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.0.1-9.tgz",
-      "integrity": "sha1-UkUzwaLLb2TL+svkDX1nG2z9KGU=",
+      "version": "2.0.1-12",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.0.1-12.tgz",
+      "integrity": "sha1-Ipohntqi3dyUdl0JpN/qjsTGP3U=",
       "requires": {
-        "@babel/runtime": "^7.0.0-beta.42",
+        "@babel/runtime": "7.0.0-beta.47",
         "bluebird": "^3.5.0",
         "sharp": "^0.20.2"
       }
     },
     "gatsby-plugin-offline": {
-      "version": "2.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-offline/-/gatsby-plugin-offline-2.0.0-alpha.8.tgz",
-      "integrity": "sha1-596F8203Mte+z7sguJpzC/H5A64=",
+      "version": "2.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-offline/-/gatsby-plugin-offline-2.0.0-alpha.11.tgz",
+      "integrity": "sha1-pljTyYfv7qABZRxnafx8sIh+VM4=",
       "requires": {
-        "@babel/runtime": "^7.0.0-beta.42",
+        "@babel/runtime": "7.0.0-beta.47",
         "sw-precache": "^5.0.0"
       }
     },
     "gatsby-plugin-react-helmet": {
-      "version": "2.0.12-2",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-2.0.12-2.tgz",
-      "integrity": "sha1-B56TJotAPicmKhFJSkubJqTrqL8=",
+      "version": "2.0.12-5",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-2.0.12-5.tgz",
+      "integrity": "sha1-+ogFKJ+QT+OXCS4hHixcDUN0hT8=",
       "requires": {
-        "@babel/runtime": "^7.0.0-beta.42"
+        "@babel/runtime": "7.0.0-beta.47"
       }
     },
     "gatsby-plugin-typography": {
-      "version": "2.0.1-6",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-typography/-/gatsby-plugin-typography-2.0.1-6.tgz",
-      "integrity": "sha1-UL7MaLylMDVpGX1ets4+cna+f3U=",
+      "version": "2.0.1-9",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-typography/-/gatsby-plugin-typography-2.0.1-9.tgz",
+      "integrity": "sha512-KR5mRs462NP0HD5mDkqnzfnFCJXqPng5MKA1LTTVfC8yXxujePbE5DsPlOdcQ+daVqRvIJFE8uo7lEqATBxSKA==",
       "requires": {
-        "@babel/runtime": "^7.0.0-beta.42"
+        "@babel/runtime": "7.0.0-beta.47"
       }
     },
     "gatsby-react-router-scroll": {
@@ -6536,6 +6521,14 @@
         "babel-runtime": "^6.26.0",
         "scroll-behavior": "^0.9.9",
         "warning": "^3.0.0"
+      }
+    },
+    "gatsby-source-wikipedia": {
+      "version": "1.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/gatsby-source-wikipedia/-/gatsby-source-wikipedia-1.0.0-alpha.2.tgz",
+      "integrity": "sha512-yqmwZeo8Poh5xyWww76VZ/aNRcviuI/gKthO/y3ZRVEawiJ8o5ETwz0TQywpDUQZzJp3fQhZhyVyROff1VQilw==",
+      "requires": {
+        "@babel/runtime": "^7.0.0-beta.38"
       }
     },
     "gauge": {
@@ -6732,13 +6725,13 @@
       }
     },
     "google-auth-library": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.4.0.tgz",
-      "integrity": "sha512-vWRx6pJulK7Y5V/Xyr7MPMlx2mWfmrUVbcffZ7hpq8ElFg5S8WY6PvjMovdcr6JfuAwwpAX4R0I1XOcyWuBcUw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.5.0.tgz",
+      "integrity": "sha512-xpibA/hkq4waBcpIkSJg4GiDAqcBWjJee3c47zj7xP3RQ0A9mc8MP3Vc9sc8SGRoDYA0OszZxTjW7SbcC4pJIA==",
       "requires": {
         "axios": "^0.18.0",
-        "gcp-metadata": "^0.6.2",
-        "gtoken": "^2.2.0",
+        "gcp-metadata": "^0.6.3",
+        "gtoken": "^2.3.0",
         "jws": "^3.1.4",
         "lodash.isstring": "^4.0.1",
         "lru-cache": "^4.1.2",
@@ -6857,11 +6850,11 @@
       }
     },
     "graphql-skip-limit": {
-      "version": "2.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/graphql-skip-limit/-/graphql-skip-limit-2.0.0-alpha.2.tgz",
-      "integrity": "sha1-20uIMw0lDX+FXYLP2W73suXaLfY=",
+      "version": "2.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/graphql-skip-limit/-/graphql-skip-limit-2.0.0-alpha.5.tgz",
+      "integrity": "sha512-5Im2MS90/vBIHlMJm27rYFYZ1HnP0sGFLhwAmTOXJ2mVunPhqmYo6RHAmpqmRX4ij4WBh9N2wfIkNWy5v9FkWQ==",
       "requires": {
-        "@babel/runtime": "^7.0.0-beta.42"
+        "@babel/runtime": "7.0.0-beta.47"
       }
     },
     "gray-percentage": {
@@ -6882,9 +6875,9 @@
       }
     },
     "guess-ga": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/guess-ga/-/guess-ga-0.0.3.tgz",
-      "integrity": "sha512-9LaZKLBAuqntj0B3t+fhdNkgqjGljbj7VZiLGVrAYLO/sVRcz8XlOV8x06/Xi/do0IfSXrJTI6PB8YSZDWCxng==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/guess-ga/-/guess-ga-0.1.0.tgz",
+      "integrity": "sha512-kUmIb9EiwfQWlB/HfUM2PJcsyRhkDygjwmArxoYkFrRkawnGk/5d3Gi1YFv0lAg1iNji7IaTYEoDdJdNi/PhhA==",
       "requires": {
         "googleapis": "^26.0.1"
       },
@@ -6903,9 +6896,9 @@
       }
     },
     "guess-parser": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/guess-parser/-/guess-parser-0.0.3.tgz",
-      "integrity": "sha512-KivW/wK04wuKXvd4HFPUwGC2mJntuJaoxP5DCm6OE6KVV9VbzDhXZ2+dZzsauTTS6jy4TWWpImd1n90AJtUk8A==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/guess-parser/-/guess-parser-0.1.0.tgz",
+      "integrity": "sha512-1ZoP8kChnf8eHDe2GZ9x4SiALBjMp2uyPAo7Nb1Df0WHOiT3EjqbULHTB0lTgfMpaM3iXbYMjCdzUmZ6Tg3Jiw==",
       "requires": {
         "@angular/compiler": "^5.2.9",
         "@angular/compiler-cli": "^5.2.9",
@@ -6917,15 +6910,15 @@
       }
     },
     "guess-webpack": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/guess-webpack/-/guess-webpack-0.0.3.tgz",
-      "integrity": "sha512-DXH5GzVxXpPfkUeESLwsvPYqmx7BBqcspTVDaK/HxH3scNq4X6gTLbowu6NQNN8Aya8NIvqCjdk1pamy1SaBvg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/guess-webpack/-/guess-webpack-0.1.0.tgz",
+      "integrity": "sha512-fNXtyAthMe0yadeQZ4yfPvjCq5TxQPf+/5covw+v1hCaTa4hl1RIZqyvFrwWyglRRRgevVIWmHVDnR00fiZALg==",
       "requires": {
         "flat-cache": "^1.3.0",
         "google-oauth2-node": "0.0.2",
         "googleapis": "^29.0.0",
-        "guess-ga": "0.0.3",
-        "guess-parser": "0.0.3",
+        "guess-ga": "0.1.0",
+        "guess-parser": "0.1.0",
         "lodash.template": "^4.4.0"
       }
     },
@@ -6999,9 +6992,9 @@
       }
     },
     "has-binary2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.2.tgz",
-      "integrity": "sha1-6D26SfC5vk0CbSc2U1DZ8D9Uvpg=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
       "requires": {
         "isarray": "2.0.1"
       },
@@ -8062,11 +8055,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
-    "isnumeric": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/isnumeric/-/isnumeric-0.2.0.tgz",
-      "integrity": "sha1-ojR7o2DeGeM9D/1ZD933dVy/LmQ="
-    },
     "isobject": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
@@ -8116,9 +8104,9 @@
       }
     },
     "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.5.tgz",
+      "integrity": "sha512-aUnNwqMOXw3yvErjMPSQu6qIIzUmT1e5KcU1OZxRDU1g/am6mzBvcrmLAYwzmB59BHPrh5/tKaiF4OPhqRWESQ=="
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -8210,28 +8198,29 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
-      "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
+      "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+      "requires": {
+        "array-includes": "^3.0.3"
+      }
     },
     "jwa": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
-      "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
+      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
       "requires": {
-        "base64url": "2.0.0",
         "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.9",
+        "ecdsa-sig-formatter": "1.0.10",
         "safe-buffer": "^5.0.1"
       }
     },
     "jws": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
-      "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
       "requires": {
-        "base64url": "^2.0.0",
-        "jwa": "^1.1.4",
+        "jwa": "^1.1.5",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -8520,9 +8509,9 @@
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
     },
     "lru-cache": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -8539,9 +8528,9 @@
       "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI="
     },
     "make-dir": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
-      "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "requires": {
         "pify": "^3.0.0"
       }
@@ -8568,6 +8557,11 @@
       "version": "1.2.17",
       "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
       "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw="
+    },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
     },
     "md5": {
       "version": "2.2.1",
@@ -9364,11 +9358,6 @@
         "wrappy": "1"
       }
     },
-    "onecolor": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/onecolor/-/onecolor-3.0.5.tgz",
-      "integrity": "sha1-Nu/zIgE3nv3xGA+0ReUajiQl+fY="
-    },
     "onetime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
@@ -9420,22 +9409,11 @@
       }
     },
     "original": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
-      "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.1.tgz",
+      "integrity": "sha512-IEvtB5vM5ULvwnqMxWBLxkS13JIEXbakizMSo3yoPNPCIWzg8TG3Usn/UhXoZFM/m+FuEA20KdzPSFq/0rS+UA==",
       "requires": {
-        "url-parse": "1.0.x"
-      },
-      "dependencies": {
-        "url-parse": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
-          "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
-          "requires": {
-            "querystringify": "0.0.x",
-            "requires-port": "1.0.x"
-          }
-        }
+        "url-parse": "~1.4.0"
       }
     },
     "os-browserify": {
@@ -9716,42 +9694,12 @@
         "pinkie": "^2.0.0"
       }
     },
-    "pixrem": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pixrem/-/pixrem-4.0.1.tgz",
-      "integrity": "sha1-LaSh3m7EQjxfw3lOkwuB1EkOxoY=",
-      "requires": {
-        "browserslist": "^2.0.0",
-        "postcss": "^6.0.0",
-        "reduce-css-calc": "^1.2.7"
-      },
-      "dependencies": {
-        "browserslist": {
-          "version": "2.11.3",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-          "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
-          "requires": {
-            "caniuse-lite": "^1.0.30000792",
-            "electron-to-chromium": "^1.3.30"
-          }
-        }
-      }
-    },
     "pkg-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "requires": {
         "find-up": "^2.1.0"
-      }
-    },
-    "pleeease-filters": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pleeease-filters/-/pleeease-filters-4.0.0.tgz",
-      "integrity": "sha1-ZjKy+wVkjSdY2GU4T7zteeHMrsc=",
-      "requires": {
-        "onecolor": "^3.0.4",
-        "postcss": "^6.0.1"
       }
     },
     "pluralize": {
@@ -9803,90 +9751,6 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
-      }
-    },
-    "postcss-apply": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/postcss-apply/-/postcss-apply-0.8.0.tgz",
-      "integrity": "sha1-FOVEu7XLbxweBIhXll15rgZrE0M=",
-      "requires": {
-        "babel-runtime": "^6.23.0",
-        "balanced-match": "^0.4.2",
-        "postcss": "^6.0.0"
-      },
-      "dependencies": {
-        "balanced-match": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-        }
-      }
-    },
-    "postcss-attribute-case-insensitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-2.0.0.tgz",
-      "integrity": "sha1-lNxCLI+QmX8WvTOjZUu77AhJY7Q=",
-      "requires": {
-        "postcss": "^6.0.0",
-        "postcss-selector-parser": "^2.2.3"
-      }
-    },
-    "postcss-browser-reporter": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/postcss-browser-reporter/-/postcss-browser-reporter-0.5.0.tgz",
-      "integrity": "sha1-rgad0IbVc4jRluHaw5y412Jv60g=",
-      "requires": {
-        "postcss": "^5.0.4"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-            }
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-        },
-        "postcss": {
-          "version": "5.2.18",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-          "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
-          }
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "requires": {
-            "has-flag": "^1.0.0"
-          }
         }
       }
     },
@@ -9948,147 +9812,6 @@
             "has-flag": "^1.0.0"
           }
         }
-      }
-    },
-    "postcss-color-function": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-color-function/-/postcss-color-function-4.0.1.tgz",
-      "integrity": "sha1-QCs/LOvD9pR+YY+2vjZU++zvZEQ=",
-      "requires": {
-        "css-color-function": "~1.3.3",
-        "postcss": "^6.0.1",
-        "postcss-message-helpers": "^2.0.0",
-        "postcss-value-parser": "^3.3.0"
-      }
-    },
-    "postcss-color-gray": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-4.1.0.tgz",
-      "integrity": "sha512-L4iLKQLdqChz6ZOgGb6dRxkBNw78JFYcJmBz1orHpZoeLtuhDDGegRtX9gSyfoCIM7rWZ3VNOyiqqvk83BEN+w==",
-      "requires": {
-        "color": "^2.0.1",
-        "postcss": "^6.0.14",
-        "postcss-message-helpers": "^2.0.0",
-        "reduce-function-call": "^1.0.2"
-      },
-      "dependencies": {
-        "color": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color/-/color-2.0.1.tgz",
-          "integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
-          "requires": {
-            "color-convert": "^1.9.1",
-            "color-string": "^1.5.2"
-          }
-        },
-        "color-string": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
-          "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
-          "requires": {
-            "color-name": "^1.0.0",
-            "simple-swizzle": "^0.2.2"
-          }
-        }
-      }
-    },
-    "postcss-color-hex-alpha": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-3.0.0.tgz",
-      "integrity": "sha1-HlPmyKyyN5Vej9CLfs2xuLgwn5U=",
-      "requires": {
-        "color": "^1.0.3",
-        "postcss": "^6.0.1",
-        "postcss-message-helpers": "^2.0.0"
-      },
-      "dependencies": {
-        "color": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/color/-/color-1.0.3.tgz",
-          "integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0=",
-          "requires": {
-            "color-convert": "^1.8.2",
-            "color-string": "^1.4.0"
-          }
-        },
-        "color-string": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
-          "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
-          "requires": {
-            "color-name": "^1.0.0",
-            "simple-swizzle": "^0.2.2"
-          }
-        }
-      }
-    },
-    "postcss-color-hsl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-color-hsl/-/postcss-color-hsl-2.0.0.tgz",
-      "integrity": "sha1-EnA2ZvoxBDDj8wpFTawThjF9WEQ=",
-      "requires": {
-        "postcss": "^6.0.1",
-        "postcss-value-parser": "^3.3.0",
-        "units-css": "^0.4.0"
-      }
-    },
-    "postcss-color-hwb": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-color-hwb/-/postcss-color-hwb-3.0.0.tgz",
-      "integrity": "sha1-NAKxnvTYSXVAwftQcr6YY8qVVx4=",
-      "requires": {
-        "color": "^1.0.3",
-        "postcss": "^6.0.1",
-        "postcss-message-helpers": "^2.0.0",
-        "reduce-function-call": "^1.0.2"
-      },
-      "dependencies": {
-        "color": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/color/-/color-1.0.3.tgz",
-          "integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0=",
-          "requires": {
-            "color-convert": "^1.8.2",
-            "color-string": "^1.4.0"
-          }
-        },
-        "color-string": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
-          "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
-          "requires": {
-            "color-name": "^1.0.0",
-            "simple-swizzle": "^0.2.2"
-          }
-        }
-      }
-    },
-    "postcss-color-rebeccapurple": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-3.1.0.tgz",
-      "integrity": "sha512-212hJUk9uSsbwO5ECqVjmh/iLsmiVL1xy9ce9TVf+X3cK/ZlUIlaMdoxje/YpsL9cmUH3I7io+/G2LyWx5rg1g==",
-      "requires": {
-        "postcss": "^6.0.22",
-        "postcss-values-parser": "^1.5.0"
-      }
-    },
-    "postcss-color-rgb": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-color-rgb/-/postcss-color-rgb-2.0.0.tgz",
-      "integrity": "sha1-FFOcinExSUtILg3RzCZf9lFLUmM=",
-      "requires": {
-        "postcss": "^6.0.1",
-        "postcss-value-parser": "^3.3.0"
-      }
-    },
-    "postcss-color-rgba-fallback": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-color-rgba-fallback/-/postcss-color-rgba-fallback-3.0.0.tgz",
-      "integrity": "sha1-N9XJNToHoJJwkSqCYGu0Kg1wLAQ=",
-      "requires": {
-        "postcss": "^6.0.6",
-        "postcss-value-parser": "^3.3.0",
-        "rgb-hex": "^2.1.0"
       }
     },
     "postcss-colormin": {
@@ -10208,112 +9931,6 @@
             "has-flag": "^1.0.0"
           }
         }
-      }
-    },
-    "postcss-cssnext": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-cssnext/-/postcss-cssnext-3.1.0.tgz",
-      "integrity": "sha512-awPDhI4OKetcHCr560iVCoDuP6e/vn0r6EAqdWPpAavJMvkBSZ6kDpSN4b3mB3Ti57hQMunHHM8Wvx9PeuYXtA==",
-      "requires": {
-        "autoprefixer": "^7.1.1",
-        "caniuse-api": "^2.0.0",
-        "chalk": "^2.0.1",
-        "pixrem": "^4.0.0",
-        "pleeease-filters": "^4.0.0",
-        "postcss": "^6.0.5",
-        "postcss-apply": "^0.8.0",
-        "postcss-attribute-case-insensitive": "^2.0.0",
-        "postcss-calc": "^6.0.0",
-        "postcss-color-function": "^4.0.0",
-        "postcss-color-gray": "^4.0.0",
-        "postcss-color-hex-alpha": "^3.0.0",
-        "postcss-color-hsl": "^2.0.0",
-        "postcss-color-hwb": "^3.0.0",
-        "postcss-color-rebeccapurple": "^3.0.0",
-        "postcss-color-rgb": "^2.0.0",
-        "postcss-color-rgba-fallback": "^3.0.0",
-        "postcss-custom-media": "^6.0.0",
-        "postcss-custom-properties": "^6.1.0",
-        "postcss-custom-selectors": "^4.0.1",
-        "postcss-font-family-system-ui": "^3.0.0",
-        "postcss-font-variant": "^3.0.0",
-        "postcss-image-set-polyfill": "^0.3.5",
-        "postcss-initial": "^2.0.0",
-        "postcss-media-minmax": "^3.0.0",
-        "postcss-nesting": "^4.0.1",
-        "postcss-pseudo-class-any-link": "^4.0.0",
-        "postcss-pseudoelements": "^5.0.0",
-        "postcss-replace-overflow-wrap": "^2.0.0",
-        "postcss-selector-matches": "^3.0.1",
-        "postcss-selector-not": "^3.0.1"
-      },
-      "dependencies": {
-        "browserslist": {
-          "version": "2.11.3",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-          "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
-          "requires": {
-            "caniuse-lite": "^1.0.30000792",
-            "electron-to-chromium": "^1.3.30"
-          }
-        },
-        "caniuse-api": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-2.0.0.tgz",
-          "integrity": "sha1-sd21pZZrFvSNxJmERNS7xsfZ2DQ=",
-          "requires": {
-            "browserslist": "^2.0.0",
-            "caniuse-lite": "^1.0.0",
-            "lodash.memoize": "^4.1.2",
-            "lodash.uniq": "^4.5.0"
-          }
-        },
-        "postcss-calc": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-6.0.1.tgz",
-          "integrity": "sha1-PSQXG79udinUIqQ26/5t2VEfQzA=",
-          "requires": {
-            "css-unit-converter": "^1.1.1",
-            "postcss": "^6.0.0",
-            "postcss-selector-parser": "^2.2.2",
-            "reduce-css-calc": "^2.0.0"
-          }
-        },
-        "reduce-css-calc": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.4.tgz",
-          "integrity": "sha512-i/vWQbyd3aJRmip9OVSN9V6nIjLf/gg/ctxb0CpvHWtcRysFl/ngDBQD+rqavxdw/doScA3GMBXhzkHQ4GCzFQ==",
-          "requires": {
-            "css-unit-converter": "^1.1.1",
-            "postcss-value-parser": "^3.3.0"
-          }
-        }
-      }
-    },
-    "postcss-custom-media": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-6.0.0.tgz",
-      "integrity": "sha1-vlMnhBEOyylQRPtTlaGABushpzc=",
-      "requires": {
-        "postcss": "^6.0.1"
-      }
-    },
-    "postcss-custom-properties": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-6.3.1.tgz",
-      "integrity": "sha512-zoiwn4sCiUFbr4KcgcNZLFkR6gVQom647L+z1p/KBVHZ1OYwT87apnS42atJtx6XlX2yI7N5fjXbFixShQO2QQ==",
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "postcss": "^6.0.18"
-      }
-    },
-    "postcss-custom-selectors": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-4.0.1.tgz",
-      "integrity": "sha1-eBOC+UxS5yfvXKR3bqKt9JphE4I=",
-      "requires": {
-        "postcss": "^6.0.1",
-        "postcss-selector-matches": "^3.0.0"
       }
     },
     "postcss-discard-comments": {
@@ -10674,51 +10291,6 @@
         "postcss": "^6.0.1"
       }
     },
-    "postcss-font-family-system-ui": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-font-family-system-ui/-/postcss-font-family-system-ui-3.0.0.tgz",
-      "integrity": "sha512-58G/hTxMSSKlIRpcPUjlyo6hV2MEzvcVO2m4L/T7Bb2fJTG4DYYfQjQeRvuimKQh1V1sOzCIz99g+H2aFNtlQw==",
-      "requires": {
-        "postcss": "^6.0"
-      }
-    },
-    "postcss-font-variant": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-3.0.0.tgz",
-      "integrity": "sha1-CMzIj2BQuoLtjvLMdsDGprQfGD4=",
-      "requires": {
-        "postcss": "^6.0.1"
-      }
-    },
-    "postcss-image-set-polyfill": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/postcss-image-set-polyfill/-/postcss-image-set-polyfill-0.3.5.tgz",
-      "integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
-      "requires": {
-        "postcss": "^6.0.1",
-        "postcss-media-query-parser": "^0.2.3"
-      }
-    },
-    "postcss-import": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-11.1.0.tgz",
-      "integrity": "sha512-5l327iI75POonjxkXgdRCUS+AlzAdBx4pOvMEhTKTCjb1p8IEeVR9yx3cPbmN7LIWJLbfnIXxAhoB4jpD0c/Cw==",
-      "requires": {
-        "postcss": "^6.0.1",
-        "postcss-value-parser": "^3.2.3",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
-      }
-    },
-    "postcss-initial": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-2.0.0.tgz",
-      "integrity": "sha1-cnFfczbgu3k1HZnuZcSiU6hEG6Q=",
-      "requires": {
-        "lodash.template": "^4.2.4",
-        "postcss": "^6.0.1"
-      }
-    },
     "postcss-load-config": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
@@ -10758,19 +10330,6 @@
         "postcss-load-config": "^1.2.0",
         "schema-utils": "^0.4.0"
       }
-    },
-    "postcss-media-minmax": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-3.0.0.tgz",
-      "integrity": "sha1-Z1JWA3pD70C8Twdgv9BtTcadSNI=",
-      "requires": {
-        "postcss": "^6.0.1"
-      }
-    },
-    "postcss-media-query-parser": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
-      "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ="
     },
     "postcss-merge-idents": {
       "version": "2.1.7",
@@ -11242,14 +10801,6 @@
         "postcss": "^6.0.1"
       }
     },
-    "postcss-nesting": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-4.2.1.tgz",
-      "integrity": "sha512-IkyWXICwagCnlaviRexi7qOdwPw3+xVVjgFfGsxmztvRVaNxAlrypOIKqDE5mxY+BVxnId1rnUKBRQoNE2VDaA==",
-      "requires": {
-        "postcss": "^6.0.11"
-      }
-    },
     "postcss-normalize-charset": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
@@ -11426,23 +10977,6 @@
             "has-flag": "^1.0.0"
           }
         }
-      }
-    },
-    "postcss-pseudo-class-any-link": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-4.0.0.tgz",
-      "integrity": "sha1-kVKgYT00UHIFE+iJKFS65C0O5o4=",
-      "requires": {
-        "postcss": "^6.0.1",
-        "postcss-selector-parser": "^2.2.3"
-      }
-    },
-    "postcss-pseudoelements": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-pseudoelements/-/postcss-pseudoelements-5.0.0.tgz",
-      "integrity": "sha1-7vGU6NUkZFylIKlJ6V5RjoEkAss=",
-      "requires": {
-        "postcss": "^6.0.0"
       }
     },
     "postcss-reduce-idents": {
@@ -11622,57 +11156,6 @@
         }
       }
     },
-    "postcss-replace-overflow-wrap": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-2.0.0.tgz",
-      "integrity": "sha1-eU22+qVPjbEAhUOSqTr0V2i04ls=",
-      "requires": {
-        "postcss": "^6.0.1"
-      }
-    },
-    "postcss-reporter": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-5.0.0.tgz",
-      "integrity": "sha512-rBkDbaHAu5uywbCR2XE8a25tats3xSOsGNx6mppK6Q9kSFGKc/FyAzfci+fWM2l+K402p1D0pNcfDGxeje5IKg==",
-      "requires": {
-        "chalk": "^2.0.1",
-        "lodash": "^4.17.4",
-        "log-symbols": "^2.0.0",
-        "postcss": "^6.0.8"
-      }
-    },
-    "postcss-selector-matches": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-3.0.1.tgz",
-      "integrity": "sha1-5WNAEeE5UIgYYbvdWMLQER/8lqs=",
-      "requires": {
-        "balanced-match": "^0.4.2",
-        "postcss": "^6.0.1"
-      },
-      "dependencies": {
-        "balanced-match": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-        }
-      }
-    },
-    "postcss-selector-not": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-3.0.1.tgz",
-      "integrity": "sha1-Lk2y8JZTNsAefOx9tsYN/3ZzNdk=",
-      "requires": {
-        "balanced-match": "^0.4.2",
-        "postcss": "^6.0.1"
-      },
-      "dependencies": {
-        "balanced-match": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-        }
-      }
-    },
     "postcss-selector-parser": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
@@ -11808,16 +11291,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
       "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
-    },
-    "postcss-values-parser": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-1.5.0.tgz",
-      "integrity": "sha512-3M3p+2gMp0AH3da530TlX8kiO1nxdTnc3C6vr8dMxRLIlh8UYkz0/wcwptSXjhtx2Fr0TySI7a+BHDQ8NL7LaQ==",
-      "requires": {
-        "flatten": "^1.0.2",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
-      }
     },
     "postcss-zindex": {
       "version": "2.2.0",
@@ -11970,6 +11443,11 @@
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
     },
+    "promise-timeout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/promise-timeout/-/promise-timeout-1.3.0.tgz",
+      "integrity": "sha512-5yANTE0tmi5++POym6OgtFmwfDvOXABD9oj/jLQr5GPEyuNEb7jH4wbbANJceJid49jwhi1RddxnhnEAb/doqg=="
+    },
     "prop-types": {
       "version": "15.6.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
@@ -12021,9 +11499,9 @@
       }
     },
     "pumpify": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.0.tgz",
-      "integrity": "sha512-UWi0klDoq8xtVzlMRgENV9F7iCTZExaJQSQL187UXsxpk9NnrKGqTqqUNYAKGOzucSOxs2+jUnRNI+rLviPhJg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "requires": {
         "duplexify": "^3.6.0",
         "inherits": "^2.0.3",
@@ -12065,44 +11543,29 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
     "querystringify": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
-      "integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+      "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
     },
     "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
         "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
         },
         "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -12303,22 +11766,22 @@
       }
     },
     "react-hot-loader": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.1.2.tgz",
-      "integrity": "sha512-7EFwgpJOx4AG4pwVifgr/ZNBPAxl2z424nGJPc/APB3F8YtCA3WdYuGlcerRK2C9vYAoqiiLw745IB3wjnzrRQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.2.0.tgz",
+      "integrity": "sha512-QqneZhA+cAbGBltg36/nivzi6Zh0PYHm4VJE2MqfEj8bAekLCqV/vqYc3fy2LIiGEctdsC+C8HCbmmCP53Ki4A==",
       "requires": {
         "fast-levenshtein": "^2.0.6",
         "global": "^4.3.0",
         "hoist-non-react-statics": "^2.5.0",
         "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.2",
+        "react-lifecycles-compat": "^3.0.4",
         "shallowequal": "^1.0.2"
       }
     },
     "react-lifecycles-compat": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.2.tgz",
-      "integrity": "sha512-pbZOSMVVkvppW7XRn9fcHK5OgEDnYLwMva7P6TgS44/SN9uGGjfh3Z1c8tomO+y4IsHQ6Fsz2EGwmE7sMeNZgQ=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-router": {
       "version": "4.2.0",
@@ -12382,21 +11845,6 @@
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "requires": {
         "mute-stream": "~0.0.4"
-      }
-    },
-    "read-cache": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
-      "requires": {
-        "pify": "^2.3.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        }
       }
     },
     "read-pkg": {
@@ -12528,14 +11976,14 @@
       "integrity": "sha512-n+IyV+nGz3+0q3/Yf1ra12KpCyi001bi4XFxSjbiWWjfqb52iTTtpGXmCCAOWWIAn9KEuFZKGqBERHmrtScZ3A=="
     },
     "regenerate": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
     },
     "regenerate-unicode-properties": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-5.1.3.tgz",
-      "integrity": "sha512-Yjy6t7jFQczDhYE+WVm7pg6gWYE258q4sUkk9qDErwXJIqx7jU9jGrMFHutJK/SRfcg7MEkXjGaYiVlOZyev/A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-6.0.0.tgz",
+      "integrity": "sha512-BvXxRS7RfVWxtm7vrq+0I0j7sqZ1zeSC+yzf5HS0qLnKcZPX541gFEGB39LvGuKHrkyKXrzXug+oC7xkM1Zovw==",
       "requires": {
         "regenerate": "^1.3.3"
       }
@@ -12576,14 +12024,14 @@
       "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw=="
     },
     "regexpu-core": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.1.3.tgz",
-      "integrity": "sha512-mB+njEzO7oezA57IbQxxd6fVPOeWKDmnGvJ485CwmfNchjHe5jWwqKepapmzUEj41yxIAqOg+C4LbXuJlkiO8A==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.1.5.tgz",
+      "integrity": "sha512-3xo5pFze1F8oR4F9x3aFbdtdxAxQ9WBX6gXfLgeBt7KpDI0+oDF7WVntnhsPKqobU/GAYc2pmx+y3z0JI1+z3w==",
       "requires": {
-        "regenerate": "^1.3.3",
-        "regenerate-unicode-properties": "^5.1.1",
-        "regjsgen": "^0.3.0",
-        "regjsparser": "^0.2.1",
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^6.0.0",
+        "regjsgen": "^0.4.0",
+        "regjsparser": "^0.3.0",
         "unicode-match-property-ecmascript": "^1.0.3",
         "unicode-match-property-value-ecmascript": "^1.0.1"
       }
@@ -12606,14 +12054,14 @@
       }
     },
     "regjsgen": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.3.0.tgz",
-      "integrity": "sha1-DuSj6SdkMM2iXx54nqbBW4ewy0M="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
+      "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA=="
     },
     "regjsparser": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.2.1.tgz",
-      "integrity": "sha1-w3h1U/rwTndcMCEC7zRtmVAA7Bw=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
+      "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
       "requires": {
         "jsesc": "~0.5.0"
       },
@@ -12815,9 +12263,9 @@
       }
     },
     "request": {
-      "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.86.0.tgz",
+      "integrity": "sha512-BQZih67o9r+Ys94tcIW4S7Uu8pthjrQVxhsZ/weOwHbDfACxvIyvnAbzFQxjy1jMtvFSzv5zf4my6cZsJBbVzw==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.6.0",
@@ -12837,7 +12285,6 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.1",
         "safe-buffer": "^5.1.1",
-        "stringstream": "~0.0.5",
         "tough-cookie": "~2.3.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.1.0"
@@ -12937,16 +12384,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-0.3.2.tgz",
       "integrity": "sha512-jp4YlI0qyDFfXiXGhkCOliBN1G7fRH03Nqy8YdShzGqbY5/9S2x/IR6C88ls2DFkbWuL3ASkP7QD3pVrNpPgwQ=="
-    },
-    "rgb": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/rgb/-/rgb-0.1.0.tgz",
-      "integrity": "sha1-vieykej+/+rBvZlylyG/pA/AN7U="
-    },
-    "rgb-hex": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/rgb-hex/-/rgb-hex-2.1.0.tgz",
-      "integrity": "sha1-x3PF/iJoolV42SU5qCp6XOU77aY="
     },
     "ric": {
       "version": "1.3.0",
@@ -13094,20 +12531,25 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
-          "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
+          "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
           "requires": {
-            "fast-deep-equal": "^1.0.0",
+            "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
             "json-schema-traverse": "^0.3.0",
-            "uri-js": "^3.0.2"
+            "uri-js": "^4.2.1"
           }
         },
         "ajv-keywords": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
           "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
         }
       }
     },
@@ -13187,9 +12629,9 @@
       "integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ=="
     },
     "serve": {
-      "version": "6.5.6",
-      "resolved": "https://registry.npmjs.org/serve/-/serve-6.5.6.tgz",
-      "integrity": "sha512-rdbHRzBh94UdZPktcoNjWEUqY0ILanZ8Q+VwNfhw5n93pkCPn86wH8x+hXgRi8II9+xj3DvGMWL/6hGUQyfuXg==",
+      "version": "6.5.7",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-6.5.7.tgz",
+      "integrity": "sha512-3Ap7l1OlEBDxrmnP72nttPvu2BKP6EDhEApVYe6NCuEGeIk5jqKyMP46nY0Svm+gdoLzXRi5KZfQSXclIPJiZw==",
       "requires": {
         "args": "4.0.0",
         "basic-auth": "2.0.0",
@@ -13211,8 +12653,9 @@
         "opn": "5.3.0",
         "path-is-inside": "1.0.2",
         "path-type": "3.0.0",
+        "promise-timeout": "1.3.0",
         "send": "0.16.2",
-        "update-check": "1.3.2"
+        "update-check": "1.5.0"
       },
       "dependencies": {
         "chalk": {
@@ -13223,6 +12666,23 @@
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "detect-port": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.2.2.tgz",
+          "integrity": "sha512-06H99JMCwgbYbA+codm97aBhFLAjABftetp+v+Z88Pvvlkawp2N+1bP/9J24+mihrvk9yBvUYTyIj3NixG1CsA==",
+          "requires": {
+            "address": "^1.0.1",
+            "debug": "^2.6.0"
           }
         },
         "filesize": {
@@ -13586,15 +13046,15 @@
       }
     },
     "socket.io": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.0.tgz",
-      "integrity": "sha512-KS+3CNWWNtLbVN5j0/B+1hjxRzey+oTK6ejpAOoxMZis6aXeB8cUtfuvjHl97tuZx+t/qD/VyqFMjuzu2Js6uQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
+      "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
       "requires": {
         "debug": "~3.1.0",
         "engine.io": "~3.2.0",
         "has-binary2": "~1.0.2",
         "socket.io-adapter": "~1.1.0",
-        "socket.io-client": "2.1.0",
+        "socket.io-client": "2.1.1",
         "socket.io-parser": "~3.2.0"
       }
     },
@@ -13604,9 +13064,9 @@
       "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
     },
     "socket.io-client": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.0.tgz",
-      "integrity": "sha512-TvKPpL0cBON5LduQfR8Rxrr+ktj70bLXGvqHCL3er5avBXruB3gpnbaud5ikFYVfANH1gCABAvo0qN8Axpg2ew==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
+      "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
       "requires": {
         "backo2": "1.0.2",
         "base64-arraybuffer": "0.1.5",
@@ -13725,11 +13185,11 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
-      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "requires": {
-        "atob": "^2.0.0",
+        "atob": "^2.1.1",
         "decode-uri-component": "^0.2.0",
         "resolve-url": "^0.2.1",
         "source-map-url": "^0.4.0",
@@ -13737,9 +13197,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
-      "integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+      "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -13929,13 +13389,13 @@
       }
     },
     "stream-http": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz",
-      "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.2.tgz",
+      "integrity": "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==",
       "requires": {
         "builtin-status-codes": "^3.0.0",
         "inherits": "^2.0.1",
-        "readable-stream": "^2.3.3",
+        "readable-stream": "^2.3.6",
         "to-arraybuffer": "^1.0.0",
         "xtend": "^4.0.0"
       }
@@ -13994,11 +13454,6 @@
       "requires": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -14180,15 +13635,15 @@
       }
     },
     "tar-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.0.tgz",
-      "integrity": "sha512-lh2iAPG/BHNmN6WB9Ybdynk9rEJ5GD/dy4zscHmVlwa1dq2tpE+BH78i5vjYwYVWEaOXGBjzxr89aVACF17Cpw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
+      "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
       "requires": {
         "bl": "^1.0.0",
         "buffer-alloc": "^1.1.0",
         "end-of-stream": "^1.0.0",
         "fs-constants": "^1.0.0",
-        "readable-stream": "^2.0.0",
+        "readable-stream": "^2.3.0",
         "to-buffer": "^1.1.0",
         "xtend": "^4.0.0"
       }
@@ -14377,9 +13832,9 @@
       }
     },
     "tslib": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
+      "integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg=="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -14664,15 +14119,6 @@
         "crypto-random-string": "^1.0.0"
       }
     },
-    "units-css": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/units-css/-/units-css-0.4.0.tgz",
-      "integrity": "sha1-1iKGU6UZg9fBb/KPi53Dsf/tOgc=",
-      "requires": {
-        "isnumeric": "^0.2.0",
-        "viewport-dimensions": "^0.2.0"
-      }
-    },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
@@ -14730,14 +14176,14 @@
       "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
     },
     "upath": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.5.tgz",
-      "integrity": "sha512-qbKn90aDQ0YEwvXoLqj0oiuUYroLX2lVHZ+b+xwjozFasAOC4GneDq5+OaIG5Zj+jFmbz/uO+f7a9qxjktJQww=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
+      "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw=="
     },
     "update-check": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/update-check/-/update-check-1.3.2.tgz",
-      "integrity": "sha512-0iGt63gXrsU4VTw4tIGVVk14H6KLHI7ExNPuSmdDdwUrUAQTBnh1hQcRpnoBWetb3/Ab4YyXK1iDWXP7D0VHTQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.0.tgz",
+      "integrity": "sha512-bSzhZ5bTcihI+Yab37pDAQc4Nmf/MvO9gwKoF+Sn5XMr2twBZG4Ri4iuSK7rpe+j8UmA9N2GUzyJtySEYjaf7w==",
       "requires": {
         "registry-auth-token": "3.3.2",
         "registry-url": "3.1.0"
@@ -14761,9 +14207,9 @@
       }
     },
     "uri-js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
-      "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.1.tgz",
+      "integrity": "sha512-jpKCA3HjsBfSDOEgxRDAxQCNyHfCPSbq57PqCkd3gAyBuPb3IWxw54EHncqESznIdqSetHfw3D7ylThu2Kcc9A==",
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -14822,13 +14268,6 @@
       "requires": {
         "querystringify": "^2.0.0",
         "requires-port": "^1.0.0"
-      },
-      "dependencies": {
-        "querystringify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
-          "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
-        }
       }
     },
     "url-parse-lax": {
@@ -14933,11 +14372,6 @@
         "extsprintf": "^1.2.0"
       }
     },
-    "viewport-dimensions": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/viewport-dimensions/-/viewport-dimensions-0.2.0.tgz",
-      "integrity": "sha1-3nQHR9tTh/0XJfUXXpG6x2r982w="
-    },
     "vm-browserify": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
@@ -14973,25 +14407,25 @@
       }
     },
     "webassemblyjs": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/webassemblyjs/-/webassemblyjs-1.3.1.tgz",
-      "integrity": "sha512-jaqGpR+MLye6fzxKTiv0/TPEm6ma7ypef76JlQVk9E1z5M2N6EXNrsMOuh7P6aXUVFHJSioRp4N9QOFpcWfIVA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/webassemblyjs/-/webassemblyjs-1.4.3.tgz",
+      "integrity": "sha512-4lOV1Lv6olz0PJkDGQEp82HempAn147e6BXijWDzz9g7/2nSebVP9GVg62Fz5ZAs55mxq13GA0XLyvY8XkyDjg==",
       "requires": {
-        "@webassemblyjs/ast": "1.3.1",
-        "@webassemblyjs/validation": "1.3.1",
-        "@webassemblyjs/wasm-parser": "1.3.1",
-        "@webassemblyjs/wast-parser": "1.3.1",
+        "@webassemblyjs/ast": "1.4.3",
+        "@webassemblyjs/validation": "1.4.3",
+        "@webassemblyjs/wasm-parser": "1.4.3",
+        "@webassemblyjs/wast-parser": "1.4.3",
         "long": "^3.2.0"
       }
     },
     "webpack": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.8.1.tgz",
-      "integrity": "sha512-xkxthzaVR298HmvmrjBCjiCmgzWnBnvBlgPzuvqmxWSh8QImrPvCCmr482YIx7ixWkTtQj1aMRz+cjoNPUsGEQ==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.8.3.tgz",
+      "integrity": "sha512-/hfAjBISycdK597lxONjKEFX7dSIU1PsYwC3XlXUXoykWBlv9QV5HnO+ql3HvrrgfBJ7WXdnjO9iGPR2aAc5sw==",
       "requires": {
-        "@webassemblyjs/ast": "1.3.1",
-        "@webassemblyjs/wasm-edit": "1.3.1",
-        "@webassemblyjs/wasm-parser": "1.3.1",
+        "@webassemblyjs/ast": "1.4.3",
+        "@webassemblyjs/wasm-edit": "1.4.3",
+        "@webassemblyjs/wasm-parser": "1.4.3",
         "acorn": "^5.0.0",
         "acorn-dynamic-import": "^3.0.0",
         "ajv": "^6.1.0",
@@ -15014,14 +14448,14 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
-          "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
+          "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
           "requires": {
-            "fast-deep-equal": "^1.0.0",
+            "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
             "json-schema-traverse": "^0.3.0",
-            "uri-js": "^3.0.2"
+            "uri-js": "^4.2.1"
           }
         },
         "ajv-keywords": {
@@ -15189,6 +14623,11 @@
               }
             }
           }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
         },
         "fill-range": {
           "version": "4.0.0",
@@ -15358,9 +14797,9 @@
       }
     },
     "webpack-hot-middleware": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.22.1.tgz",
-      "integrity": "sha512-wbjnvcc3HOPKRE/L0KmTv2MrByfLFOJlVFNKo5Svxy+1plR/bMIMYQDgB4pUOzJXhiBLU7Clp6P1SSzS89iKxA==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.22.2.tgz",
+      "integrity": "sha512-uccPS6b/UlXJoNCS+3fuc40z2KZgO0qQhnu+Ne1iZiHTy9s5fMCJAV+Vc8VTVkN203UphsxQmkumxYeHLiQ5jg==",
       "requires": {
         "ansi-html": "0.0.7",
         "html-entities": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/guess-js/gatsby-guess/issues"
   },
   "resolutions": {
-    "guess-ga": "^0.0.2",
-    "guess-parser": "^0.0.2"
+    "guess-ga": "^0.1.0",
+    "guess-parser": "^0.1.0"
   },
   "dependencies": {
     "axios": "^0.18.0",
@@ -21,7 +21,7 @@
     "gatsby-plugin-react-helmet": "next",
     "gatsby-plugin-typography": "next",
     "gatsby-source-wikipedia": "^1.0.0-alpha.2",
-    "guess-webpack": "^0.0.3",
+    "guess-webpack": "^0.1.0",
     "node-fetch": "^2.1.2",
     "querystring": "^0.2.0",
     "react": "^16.3.2",

--- a/plugins/gatsby-guess-js-link-highlight/gatsby-browser.js
+++ b/plugins/gatsby-guess-js-link-highlight/gatsby-browser.js
@@ -18,9 +18,7 @@ const highlight = e => {
 };
 
 const colorLinks = () => {
-  const guesses = guess(
-    window.location.pathname.slice(-1) === `/` ? window.location.pathname.slice(0, -1) : window.location.pathname
-  );
+  const guesses = guess(window.location.pathname);
   [].slice.call(document.querySelectorAll(`a`)).forEach(n => n.classList.add('prefetch-priority-0'));
   let all = Object.keys(guesses).map(key => guesses[key]);
   all = all.filter((p, idx) => all.indexOf(p) === idx); //.sort((a, b) => a - b);
@@ -40,7 +38,7 @@ const colorLinks = () => {
       color = 2;
     }
     [].slice
-      .call(document.querySelectorAll(`[href="${c}/"]`))
+      .call(document.querySelectorAll(`[href="${c}"]`))
       .concat([].slice.call(document.querySelectorAll(`[href="${c}"]`)))
       .forEach(n => n.classList.add(`prefetch-priority-${color}`));
   });


### PR DESCRIPTION
We should re-deploy when we publish new patch version of https://github.com/guess-js/guess. We should also reflect the changes in the gatsby plugin. The prefetching doesn't seem to work properly now.

- We're also using newer GA data which includes the `wiki` prefix.
- Not adding artificial `/` suffix anymore.